### PR TITLE
feat: technical test implementation — David Funez Cruz

### DIFF
--- a/docs/local-curls.md
+++ b/docs/local-curls.md
@@ -1,0 +1,255 @@
+# Local cURLs — ulyses.technical.test
+
+Collection of `curl` commands to exercise the API locally after starting the
+service (`./mvnw spring-boot:run`). Ordered so that write operations always
+target resources created within the same session and do not conflict with the
+foreign key constraints defined in `data.sql`.
+
+> **Base URL**: `http://localhost:8080`
+> **Auth**: `admin:admin` (write operations), `user:user` (read-only).
+> **Preloaded data**: brands 1–3 (Renault, Opel, VW), vehicles 1–9, ~50 sales
+> per vehicle in January 2025.
+> **Convention**: IDs 1–3 (brands) and 1–9 (vehicles) are **read-only**.
+> All write operations must target resources created in the `*.CREATE` steps
+> (IDs ≥ 4 for brands, ≥ 10 for vehicles).
+
+---
+
+## 0. Health / H2 console
+
+```bash
+# H2 console (browser): http://localhost:8080/h2-console
+#   JDBC URL: jdbc:h2:mem:testdb  ·  user: sa  ·  password: password
+
+curl -i http://localhost:8080/api/brands   # connectivity check
+```
+
+---
+
+## 1. Public read operations (order-independent, no state mutation)
+
+### 1.1 Brands
+```bash
+curl -i http://localhost:8080/api/brands                # populates "all" cache entry
+curl -i http://localhost:8080/api/brands                # 2nd request → served from cache
+curl -i http://localhost:8080/api/brands/1              # cache by id
+curl -i http://localhost:8080/api/brands/2
+curl -i http://localhost:8080/api/brands/3
+curl -i http://localhost:8080/api/brands/9999           # 404
+```
+
+### 1.2 Vehicles
+```bash
+curl -i http://localhost:8080/api/vehicles
+curl -i http://localhost:8080/api/vehicles/1            # Clio
+curl -i http://localhost:8080/api/vehicles/9            # Tiguan
+curl -i http://localhost:8080/api/vehicles/9999         # 404
+```
+
+### 1.3 Sales (pagination + filters + best-selling)
+```bash
+# Pagination
+curl -i http://localhost:8080/api/sales                 # default page=1
+curl -i 'http://localhost:8080/api/sales?page=1'
+curl -i 'http://localhost:8080/api/sales?page=2'
+curl -i 'http://localhost:8080/api/sales?page=50'
+curl -i 'http://localhost:8080/api/sales?page=99999'    # 200, data=[], hasMore=false
+
+# Validation errors
+curl -i 'http://localhost:8080/api/sales?page=0'        # 400
+curl -i 'http://localhost:8080/api/sales?page=-1'       # 400
+curl -i 'http://localhost:8080/api/sales?page=abc'      # 400
+
+# Detail
+curl -i http://localhost:8080/api/sales/1
+curl -i http://localhost:8080/api/sales/9999999         # 404
+curl -i http://localhost:8080/api/sales/0               # 400
+
+# Filter by brand / vehicle
+curl -i http://localhost:8080/api/sales/brands/1
+curl -i http://localhost:8080/api/sales/brands/2
+curl -i http://localhost:8080/api/sales/brands/3
+curl -i http://localhost:8080/api/sales/brands/-3       # 400
+curl -i http://localhost:8080/api/sales/vehicles/1
+curl -i http://localhost:8080/api/sales/vehicles/9
+curl -i http://localhost:8080/api/sales/vehicles/0      # 400
+
+# Best-selling vehicles
+curl -i http://localhost:8080/api/sales/vehicles/bestSelling
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?startDate=2025-01-01&endDate=2025-01-02'
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?startDate=2025-01-01&endDate=2025-01-31'
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?startDate=2025-01-10'
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?endDate=2025-01-05'
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?startDate=2025-02-01&endDate=2025-01-01'  # 400 (inverted range)
+curl -i 'http://localhost:8080/api/sales/vehicles/bestSelling?startDate=01-01-2025'                     # 400 (wrong format)
+```
+
+---
+
+## 2. Security checks (no relevant state mutation)
+
+```bash
+# Write without credentials → 401
+curl -i -X POST   http://localhost:8080/api/brands  -H 'Content-Type: application/json' -d '{}'
+curl -i -X DELETE http://localhost:8080/api/brands/1
+
+# Write with USER role → 403
+curl -i -u user:user -X POST   http://localhost:8080/api/brands  -H 'Content-Type: application/json' -d '{"name":"x","description":"x"}'
+curl -i -u user:user -X DELETE http://localhost:8080/api/brands/1
+
+# Wrong credentials → 401
+curl -i -u admin:wrong -X PUT http://localhost:8080/api/brands/1 -H 'Content-Type: application/json' -d '{"name":"x","description":"x"}'
+```
+> The `DELETE /api/brands/1` and `PUT /api/brands/1` commands above **fail
+> before reaching the database** (401/403), so they are safe even though they
+> target preloaded IDs.
+
+---
+
+## 3. Write operations (order matters — always use self-created IDs)
+
+> ⚠️ Follow the order. Each block creates a resource and reuses its ID in
+> subsequent steps. Assumes the first `POST /api/brands` returns ID `4` and
+> the first `POST /api/vehicles` returns ID `10`. If you have made prior
+> creations in the same session, adjust the IDs to the values returned in the
+> `Location` header or response body.
+
+### 3.1 Brands — create, update, delete (own brand only)
+```bash
+# 3.1.1 CREATE → 201, evicts "all" cache entry
+curl -i -u admin:admin -X POST http://localhost:8080/api/brands \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Peugeot","description":"French manufacturer"}'
+
+# 3.1.2 GET to confirm the returned ID (assumed 4)
+curl -i http://localhost:8080/api/brands/4
+
+# 3.1.3 UPDATE a brand without vehicles → 200 (safe, does not trigger orphanRemoval FK violations)
+curl -i -u admin:admin -X PUT http://localhost:8080/api/brands/4 \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Peugeot-Updated","description":"edited"}'
+
+# 3.1.4 UPDATE non-existent ID → 404
+curl -i -u admin:admin -X PUT http://localhost:8080/api/brands/9999 \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"x","description":"x"}'
+
+# 3.1.5 DELETE the brand just created → 204
+curl -i -u admin:admin -X DELETE http://localhost:8080/api/brands/4
+
+# 3.1.6 DELETE non-existent ID → 404
+curl -i -u admin:admin -X DELETE http://localhost:8080/api/brands/9999
+```
+
+### 3.2 Vehicles — create, update, delete (own vehicle only)
+```bash
+# 3.2.1 CREATE under an existing brand (id=1, reference only) → 201
+curl -i -u admin:admin -X POST http://localhost:8080/api/vehicles \
+  -H 'Content-Type: application/json' \
+  -d '{"brand":{"id":1},"model":"Kadjar","year":"2024","color":"Gray"}'
+
+# 3.2.2 GET to confirm the returned ID (assumed 10)
+curl -i http://localhost:8080/api/vehicles/10
+
+# 3.2.3 CREATE with non-existent brand → 400
+curl -i -u admin:admin -X POST http://localhost:8080/api/vehicles \
+  -H 'Content-Type: application/json' \
+  -d '{"brand":{"id":9999},"model":"Ghost","year":"2024","color":"None"}'
+
+# 3.2.4 UPDATE own vehicle → 200
+curl -i -u admin:admin -X PUT http://localhost:8080/api/vehicles/10 \
+  -H 'Content-Type: application/json' \
+  -d '{"brand":{"id":1},"model":"Kadjar GT","year":"2024","color":"Black"}'
+
+# 3.2.5 UPDATE non-existent ID → 404
+curl -i -u admin:admin -X PUT http://localhost:8080/api/vehicles/9999 \
+  -H 'Content-Type: application/json' \
+  -d '{"brand":{"id":1},"model":"X","year":"2024","color":"Black"}'
+
+# 3.2.6 DELETE own vehicle → 204 (no associated sales)
+curl -i -u admin:admin -X DELETE http://localhost:8080/api/vehicles/10
+```
+
+---
+
+## ⚠️ Known limitations (out of scope — documented, not fixed)
+
+The following are behaviours inherited from the original scaffold. They can
+break a request if the execution order above is not respected. They are **not
+covered by the assignment README** and therefore fall outside the scope of this
+implementation.
+
+### G1. `PUT /api/brands/{id}` on a brand that has vehicles → 500 (FK violation)
+Example:
+```bash
+# ❌ DO NOT target IDs 1, 2 or 3 (they have associated vehicles and, transitively, sales)
+curl -i -u admin:admin -X PUT http://localhost:8080/api/brands/1 \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Renault-Updated","description":"edited"}'
+```
+- **Symptom**: `org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException` on
+  `FK ... SALES.VEHICLE_ID → VEHICLES.ID`.
+- **Root cause**: `Brand.vehicles` is declared with `cascade = ALL, orphanRemoval = true`.
+  The controller calls `brand.setId(id); save(brand);` with a `Brand` object
+  deserialized from JSON that **does not include `vehicles`** → JPA interprets
+  the collection as empty → attempts to delete existing vehicles → any vehicle
+  referenced by a `sales` row violates the FK constraint.
+- **Workarounds** (without touching the code):
+  - Only run PUT against brands you created yourself **with no associated
+    vehicles** (steps 3.1.x).
+  - Or explicitly include the vehicle references in the request body:
+    ```bash
+    curl -i -u admin:admin -X PUT http://localhost:8080/api/brands/1 \
+      -H 'Content-Type: application/json' \
+      -d '{"name":"Renault-Updated","description":"edited","vehicles":[{"id":1},{"id":2},{"id":3}]}'
+    ```
+
+### G2. `DELETE /api/vehicles/{id}` on a vehicle with associated sales → 500 (FK violation)
+- **Symptom**: same type of integrity violation on `SALES.VEHICLE_ID`.
+- **Root cause**: there is no cascade from `Vehicle` to `Sales`. Deleting a
+  vehicle referenced by rows in `sales` fails.
+- **Workaround**: only delete vehicles created by you (step 3.2.6), never IDs 1–9.
+
+### G3. `DELETE /api/brands/{id}` on a brand with vehicles
+- **Symptom**: `Brand.vehicles` cascades ALL, so deletion propagates to
+  vehicles → which then collide with the `sales` FK if the brand has
+  associated sales.
+- **Workaround**: only delete brands created by you, with no vehicles or
+  sales attached (step 3.1.5).
+
+### G4. Brand cache and manual H2 console mutations
+If data is modified directly from `/h2-console`, the brand cache (TTL 60 s)
+is not notified. Wait for the TTL to expire or trigger a `POST/PUT/DELETE`
+on `/api/brands/**` to force cache eviction.
+
+### G5. Invalid GETs returning 401 instead of 400/404 — **RESOLVED**
+- **Original symptom**: `GET /api/sales?page=0`, `GET /api/sales/0`,
+  `GET /api/sales/brands/-3`, `GET /api/sales/vehicles/bestSelling` with an
+  inverted date range, etc. → clients received `401` with
+  `WWW-Authenticate: Basic`, while `logs/access.log` correctly recorded `400`.
+- **Root cause**: when a public endpoint throws a `ResponseStatusException`,
+  Spring performs an internal `FORWARD` to `/error`. The Security filter chain
+  re-evaluates that path, and `/error` was not included in `permitAll()` →
+  it fell through to `anyRequest().authenticated()` → 401.
+- **Fix applied** in `SecurityConfig.securityFilterChain`:
+  ```java
+  .requestMatchers("/error").permitAll()
+  ```
+  This is strictly outside the assignment README scope, but it is a trivial,
+  low-risk change: `/error` is a Spring internal endpoint reached only via
+  container dispatch, does not expose sensitive information, and does not
+  weaken the `POST/PUT/DELETE` rules (they still require `ADMIN`). Without
+  it, any query/path validation on a GET endpoint is unusable by external
+  clients.
+- **Not caught by ITs** because `MockMvc` does not process the `/error`
+  dispatch the same way a real servlet container does.
+
+---
+
+## 4. Access log verification
+
+```bash
+tail -n 20 logs/access.log
+```
+Each request should appear with its timestamp, HTTP method, URL, response
+status, and duration in milliseconds.

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,18 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/septeo/ulyses/technical/test/cache/CacheEntry.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/cache/CacheEntry.java
@@ -1,0 +1,10 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import java.time.Instant;
+
+record CacheEntry(Object value, Instant expiresAt) {
+
+    boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/cache/TtlCache.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/cache/TtlCache.java
@@ -1,0 +1,164 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.SimpleValueWrapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Concurrent cache with per-entry TTL.
+ *
+ * <p>Concurrency: a single {@link ConcurrentHashMap} stores one
+ * {@link CompletableFuture} per key, which holds either the in-flight load or
+ * the resolved {@link CacheEntry}. {@link #get(Object, Callable)} uses
+ * {@link ConcurrentHashMap#compute compute} only to atomically swap the future
+ * reference (a trivial operation), while the expensive loader runs
+ * <em>outside</em> any bucket lock. As a result, a slow loader for one key
+ * never blocks lookups, inserts or evictions for other keys that happen to
+ * hash to the same bucket, and concurrent callers for the same key share the
+ * same future and observe its single value.
+ */
+@Slf4j
+public class TtlCache implements Cache {
+
+    private static final String LOG_PREFIX = "[CACHE] ";
+
+    private final String name;
+    private final Duration ttl;
+    private final ConcurrentHashMap<Object, CompletableFuture<CacheEntry>> store = new ConcurrentHashMap<>();
+
+    public TtlCache(String name, Duration ttl) {
+        this.name = name;
+        this.ttl = ttl;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return store;
+    }
+
+    @Override
+    public ValueWrapper get(Object key) {
+        final CacheEntry entry = readFresh(key);
+        return entry == null ? null : new SimpleValueWrapper(entry.value());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Object key, Class<T> type) {
+        final CacheEntry entry = readFresh(key);
+        if (entry == null) {
+            return null;
+        }
+        final Object value = entry.value();
+        if (value != null && type != null && !type.isInstance(value)) {
+            throw new IllegalStateException("Cached value is not of required type [%s]: %s".formatted(type.getName(), value));
+        }
+        return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        final CompletableFuture<CacheEntry> mine = new CompletableFuture<>();
+        // compute() only swaps a reference; the loader runs OUTSIDE the bucket lock.
+        final CompletableFuture<CacheEntry> future = store.compute(key, (k, existing) -> isReusable(existing) ? existing : mine);
+
+        if (future != mine) {
+            log.debug("{}{} hit/follower key={}", LOG_PREFIX, name, key);
+            return (T) awaitValue(future);
+        }
+
+        try {
+            log.debug("{}{} miss - invoking loader key={}", LOG_PREFIX, name, key);
+            final CacheEntry entry = new CacheEntry(valueLoader.call(), Instant.now().plus(ttl));
+            mine.complete(entry);
+            return (T) entry.value();
+        } catch (Exception e) {
+            log.error("{}{} loader failed key={}", LOG_PREFIX, name, key, e);
+            final ValueRetrievalException wrapped = new ValueRetrievalException(key, valueLoader, e);
+            mine.completeExceptionally(wrapped);
+            // Remove the failed entry so subsequent calls retry instead of replaying the failure.
+            store.remove(key, mine);
+            throw wrapped;
+        }
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        store.put(key, CompletableFuture.completedFuture(new CacheEntry(value, Instant.now().plus(ttl))));
+    }
+
+    @Override
+    public void evict(Object key) {
+        log.debug("{}{} evict key={}", LOG_PREFIX, name, key);
+        store.remove(key);
+    }
+
+    @Override
+    public void clear() {
+        log.debug("{}{} clear", LOG_PREFIX, name);
+        store.clear();
+    }
+
+    /**
+     * A cached future can be reused when it is still loading, or already resolved with a non-expired value.
+     *
+     * @param existing the cached future to evaluate, may be {@code null}
+     * @return {@code true} if the future is still in-flight or holds a valid, non-expired entry;
+     *         {@code false} if it is {@code null}, completed exceptionally, or the entry has expired
+     */
+    private static boolean isReusable(CompletableFuture<CacheEntry> existing) {
+        if (existing == null) {
+            return false;
+        }
+        if (!existing.isDone()) {
+            return true;
+        }
+        if (existing.isCompletedExceptionally()) {
+            return false;
+        }
+        final CacheEntry entry = existing.getNow(null);
+        return entry != null && !entry.isExpired();
+    }
+
+    private CacheEntry readFresh(Object key) {
+        final CompletableFuture<CacheEntry> future = store.get(key);
+        if (future == null || !future.isDone() || future.isCompletedExceptionally()) {
+            return null;
+        }
+        final CacheEntry entry = future.getNow(null);
+        if (entry == null) {
+            return null;
+        }
+        if (entry.isExpired()) {
+            log.debug("{}{} entry expired key={}", LOG_PREFIX, name, key);
+            store.remove(key, future);
+            return null;
+        }
+        return entry;
+    }
+
+    private static Object awaitValue(CompletableFuture<CacheEntry> running) {
+        try {
+            return running.join().value();
+        } catch (CompletionException ce) {
+            // The leader thread already wrapped the original failure into ValueRetrievalException.
+            if (ce.getCause() instanceof ValueRetrievalException vre) {
+                throw vre;
+            }
+            throw ce;
+        }
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/cache/TtlCacheManager.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/cache/TtlCacheManager.java
@@ -1,0 +1,30 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import jakarta.annotation.Nonnull;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TtlCacheManager implements CacheManager {
+
+    private final Duration ttl;
+    private final ConcurrentHashMap<String, Cache> caches = new ConcurrentHashMap<>();
+
+    public TtlCacheManager(Duration ttl) {
+        this.ttl = ttl;
+    }
+
+    @Override
+    public Cache getCache(String name) {
+        return caches.computeIfAbsent(name, key -> new TtlCache(key, ttl));
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return Collections.unmodifiableSet(caches.keySet());
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/config/CacheConfig.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.septeo.ulyses.technical.test.config;
+
+import com.septeo.ulyses.technical.test.cache.TtlCacheManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String BRANDS_CACHE = "brands";
+    public static final String BRANDS_ALL_KEY = "all";
+
+    @Bean
+    public CacheManager cacheManager(@Value("${app.cache.brands.ttl-seconds:60}") long ttlSeconds) {
+        return new TtlCacheManager(Duration.ofSeconds(ttlSeconds));
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/config/SecurityConfig.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/config/SecurityConfig.java
@@ -1,10 +1,78 @@
 package com.septeo.ulyses.technical.test.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+/**
+ * HTTP security:
+ * <ul>
+ *   <li>GET endpoints are public.</li>
+ *   <li>POST/PUT/DELETE require role {@code ADMIN}.</li>
+ *   <li>H2 console is left open (development convenience).</li>
+ * </ul>
+ * Stateless API: CSRF disabled and no HTTP session.
+ */
 @Configuration
 public class SecurityConfig {
 
-    // TODO: implement here your security configuration
+    private static final String ADMIN_ROLE = "ADMIN";
+    private static final String USER_ROLE = "USER";
 
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**")).permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/**").hasRole(ADMIN_ROLE)
+                        .requestMatchers(HttpMethod.PUT, "/api/**").hasRole(ADMIN_ROLE)
+                        .requestMatchers(HttpMethod.DELETE, "/api/**").hasRole(ADMIN_ROLE)
+                        .anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(
+            PasswordEncoder encoder,
+            @Value("${app.security.user.username}") String userName,
+            @Value("${app.security.user.password}") String userPassword,
+            @Value("${app.security.admin.username}") String adminName,
+            @Value("${app.security.admin.password}") String adminPassword) {
+
+        final UserDetails user = User.withUsername(userName)
+                .password(encoder.encode(userPassword))
+                .roles(USER_ROLE)
+                .build();
+
+        final UserDetails admin = User.withUsername(adminName)
+                .password(encoder.encode(adminPassword))
+                .roles(ADMIN_ROLE, USER_ROLE)
+                .build();
+
+        return new InMemoryUserDetailsManager(user, admin);
+    }
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/controller/SalesController.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/controller/SalesController.java
@@ -1,35 +1,74 @@
 package com.septeo.ulyses.technical.test.controller;
 
+import com.septeo.ulyses.technical.test.dto.BestSellingVehicleResponse;
+import com.septeo.ulyses.technical.test.dto.PageResponse;
 import com.septeo.ulyses.technical.test.entity.Sales;
 import com.septeo.ulyses.technical.test.service.SalesService;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.septeo.ulyses.technical.test.validation.RequestValidations;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/sales")
+@RequiredArgsConstructor
+@Slf4j
 public class SalesController {
 
-    @Autowired
-    private SalesService salesService;
+    private static final String LOG_PREFIX = "[SALES-API] ";
+    private static final int PAGE_SIZE = 10;
+    private static final int MIN_PAGE = 1;
+
+    private final SalesService salesService;
 
     @GetMapping
-    public ResponseEntity<List<Sales>> getAllSales() {
-        return ResponseEntity.ok(salesService.getAllSales());
+    public ResponseEntity<PageResponse<Sales>> getAllSales(@RequestParam(defaultValue = "1") int page) {
+        log.debug("{}GET /api/sales page={}", LOG_PREFIX, page);
+        RequestValidations.minimum(page, MIN_PAGE, "page");
+        return ResponseEntity.ok(salesService.getSalesPage(page, PAGE_SIZE));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<Sales> getSalesById(@PathVariable Long id) {
+        log.debug("{}GET /api/sales/{}", LOG_PREFIX, id);
+        RequestValidations.positive(id, "id");
+
         return salesService.getSalesById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    // TODO: implement here your endpoints
+    @GetMapping("/brands/{brandId}")
+    public ResponseEntity<List<Sales>> getSalesByBrand(@PathVariable Long brandId) {
+        log.debug("{}GET /api/sales/brands/{}", LOG_PREFIX, brandId);
+        RequestValidations.positive(brandId, "brandId");
 
+        return ResponseEntity.ok(salesService.getSalesByBrand(brandId));
+    }
+
+    @GetMapping("/vehicles/{vehicleId}")
+    public ResponseEntity<List<Sales>> getSalesByVehicle(@PathVariable Long vehicleId) {
+        log.debug("{}GET /api/sales/vehicles/{}", LOG_PREFIX, vehicleId);
+        RequestValidations.positive(vehicleId, "vehicleId");
+        return ResponseEntity.ok(salesService.getSalesByVehicle(vehicleId));
+    }
+
+    @GetMapping("/vehicles/bestSelling")
+    public ResponseEntity<List<BestSellingVehicleResponse>> getBestSellingVehicles(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        log.debug("{}GET /api/sales/vehicles/bestSelling startDate={} endDate={}", LOG_PREFIX, startDate, endDate);
+        RequestValidations.dateRange(startDate, endDate);
+        return ResponseEntity.ok(salesService.getBestSellingVehicles(startDate, endDate));
+    }
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/dto/BestSellingVehicleResponse.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/dto/BestSellingVehicleResponse.java
@@ -1,0 +1,4 @@
+package com.septeo.ulyses.technical.test.dto;
+
+public record BestSellingVehicleResponse(Long vehicleId, String brand, String model, String year, long totalSales) {
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/dto/PageResponse.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/dto/PageResponse.java
@@ -1,0 +1,10 @@
+package com.septeo.ulyses.technical.test.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(List<T> data, PaginationInfo pagination) {
+
+    public static <T> PageResponse<T> of(List<T> data, int page, int pageSize, boolean hasMore) {
+        return new PageResponse<>(data, new PaginationInfo(hasMore, page, pageSize));
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/dto/PaginationInfo.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/dto/PaginationInfo.java
@@ -1,0 +1,4 @@
+package com.septeo.ulyses.technical.test.dto;
+
+public record PaginationInfo(boolean hasMore, int page, int pageSize) {
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/entity/Brand.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/entity/Brand.java
@@ -1,5 +1,7 @@
 package com.septeo.ulyses.technical.test.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,6 +26,7 @@ public class Brand {
 
     private String description;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "brand", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Vehicle> vehicles = new ArrayList<>();
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/entity/Sales.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/entity/Sales.java
@@ -25,6 +25,7 @@ public class Sales {
     @JoinColumn(name = "brand_id", nullable = false)
     private Brand brand;
 
+    @JsonIgnoreProperties("brand")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vehicle_id", nullable = false)
     private Vehicle vehicle;

--- a/src/main/java/com/septeo/ulyses/technical/test/entity/Sales.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/entity/Sales.java
@@ -21,11 +21,11 @@ public class Sales {
     private Long id;
 
     @JsonIgnoreProperties("vehicles")
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id", nullable = false)
     private Brand brand;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vehicle_id", nullable = false)
     private Vehicle vehicle;
 

--- a/src/main/java/com/septeo/ulyses/technical/test/logging/AccessLogFilter.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/logging/AccessLogFilter.java
@@ -1,0 +1,71 @@
+package com.septeo.ulyses.technical.test.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Logs every HTTP request and its response to a dedicated access log file.
+ *
+ * <p>The fully qualified class name is referenced in {@code logback-spring.xml}
+ * to route this logger's output to its own file appender with
+ * {@code additivity=false}, so access lines never leak into the console/root log.
+ *
+ * <p>The filter is auto-registered by Spring Boot as a {@code @Component} and pinned
+ * to {@link Ordered#HIGHEST_PRECEDENCE} so it wraps every other servlet filter,
+ * including the Spring Security filter chain. This guarantees that:
+ * <ul>
+ *   <li>Requests rejected by Spring Security (e.g. {@code 401}/{@code 403}) are still logged.</li>
+ *   <li>The status read from the response in the {@code finally} block is the final
+ *       status returned to the client.</li>
+ *   <li>The measured elapsed time covers the full request lifecycle.</li>
+ * </ul>
+ * No {@code FilterRegistrationBean} is needed because we do not require custom URL
+ * patterns, dispatcher types or init params: the {@link Order} annotation is enough
+ * to control the position of the filter in the chain.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AccessLogFilter extends OncePerRequestFilter {
+
+    private static final Logger ACCESS_LOG = LoggerFactory.getLogger(AccessLogFilter.class);
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final long startNanos = System.nanoTime();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            ACCESS_LOG.info("{} | {} | {} | {} | {}ms",
+                    OffsetDateTime.now(ZoneOffset.UTC).format(TIMESTAMP_FORMAT),
+                    request.getMethod(),
+                    buildFullUrl(request),
+                    response.getStatus(),
+                    elapsedMillis(startNanos));
+        }
+    }
+
+    private static String buildFullUrl(HttpServletRequest request) {
+        final String query = request.getQueryString();
+        return query == null ? request.getRequestURI() : request.getRequestURI() + "?" + query;
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/repository/SalesRepository.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/repository/SalesRepository.java
@@ -1,11 +1,8 @@
 package com.septeo.ulyses.technical.test.repository;
 
-import com.septeo.ulyses.technical.test.entity.Brand;
 import com.septeo.ulyses.technical.test.entity.Sales;
-import com.septeo.ulyses.technical.test.entity.Vehicle;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,4 +26,17 @@ public interface SalesRepository {
      */
     Optional<Sales> findById(Long id);
 
+    /**
+     * Page-based slice of sales. Implementations should fetch {@code pageSize + 1}
+     * rows to compute {@code hasMore} without a separate {@code COUNT} query.
+     *
+     * @param page     1-based page number
+     * @param pageSize items per page
+     * @return at most {@code pageSize + 1} sales (the last one only signals there is more data)
+     */
+    List<Sales> findPage(int page, int pageSize);
+
+    List<Sales> findByBrandId(Long brandId);
+
+    List<Sales> findByVehicleId(Long vehicleId);
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/repository/SalesRepositoryImpl.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/repository/SalesRepositoryImpl.java
@@ -1,15 +1,13 @@
 package com.septeo.ulyses.technical.test.repository;
 
-import com.septeo.ulyses.technical.test.entity.Brand;
 import com.septeo.ulyses.technical.test.entity.Sales;
-import com.septeo.ulyses.technical.test.entity.Vehicle;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,28 +16,66 @@ import java.util.Optional;
  * This class provides the implementation for all sales-related operations.
  */
 @Repository
+@Slf4j
 public class SalesRepositoryImpl implements SalesRepository {
+
+    private static final String LOG_PREFIX = "[SALES-REPO] ";
+
+    // Single source of truth for the hydration contract: every query in this repository
+    // returns Sales with brand and vehicle eagerly joined to avoid N+1 on the service layer.
+    private static final String SELECT_WITH_GRAPH =
+            "SELECT s FROM Sales s JOIN FETCH s.brand JOIN FETCH s.vehicle";
 
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
     public List<Sales> findAll() {
-        String stringQuery = "SELECT s FROM Sales s";
-        Query query = entityManager.createQuery(stringQuery);
-        return query.getResultList();
+        log.debug("{}findAll", LOG_PREFIX);
+        return entityManager
+                .createQuery(SELECT_WITH_GRAPH, Sales.class)
+                .getResultList();
     }
 
     @Override
     public Optional<Sales> findById(Long id) {
-        String stringQuery = "SELECT s FROM Sales s WHERE s.id = :id";
-        Query query = entityManager.createQuery(stringQuery);
-        query.setParameter("id", id);
+        log.debug("{}findById id={}", LOG_PREFIX, id);
+        final TypedQuery<Sales> query = entityManager
+                .createQuery(SELECT_WITH_GRAPH + " WHERE s.id = :id", Sales.class)
+                .setParameter("id", id);
 
         try {
-            return Optional.of((Sales) query.getSingleResult());
+            return Optional.of(query.getSingleResult());
         } catch (NoResultException e) {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public List<Sales> findPage(int page, int pageSize) {
+        log.debug("{}findPage page={} pageSize={}", LOG_PREFIX, page, pageSize);
+        return entityManager
+                .createQuery(SELECT_WITH_GRAPH + " ORDER BY s.id ASC", Sales.class)
+                .setFirstResult((page - 1) * pageSize)
+                .setMaxResults(pageSize + 1)
+                .getResultList();
+    }
+
+    @Override
+    public List<Sales> findByBrandId(Long brandId) {
+        log.debug("{}findByBrandId brandId={}", LOG_PREFIX, brandId);
+        return entityManager
+                .createQuery(SELECT_WITH_GRAPH + " WHERE s.brand.id = :brandId", Sales.class)
+                .setParameter("brandId", brandId)
+                .getResultList();
+    }
+
+    @Override
+    public List<Sales> findByVehicleId(Long vehicleId) {
+        log.debug("{}findByVehicleId vehicleId={}", LOG_PREFIX, vehicleId);
+        return entityManager
+                .createQuery(SELECT_WITH_GRAPH + " WHERE s.vehicle.id = :vehicleId", Sales.class)
+                .setParameter("vehicleId", vehicleId)
+                .getResultList();
     }
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/repository/VehicleRepositoryImpl.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/repository/VehicleRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.septeo.ulyses.technical.test.repository;
 
-import com.septeo.ulyses.technical.test.entity.Brand;
 import com.septeo.ulyses.technical.test.entity.Vehicle;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;

--- a/src/main/java/com/septeo/ulyses/technical/test/service/BrandServiceImpl.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/BrandServiceImpl.java
@@ -1,8 +1,13 @@
 package com.septeo.ulyses.technical.test.service;
 
+import com.septeo.ulyses.technical.test.config.CacheConfig;
 import com.septeo.ulyses.technical.test.entity.Brand;
 import com.septeo.ulyses.technical.test.repository.BrandRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,41 +19,52 @@ import java.util.Optional;
  * This class provides the implementation for all brand-related operations.
  */
 @Service
-@Transactional(readOnly = false)
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
 public class BrandServiceImpl implements BrandService {
 
-    @Autowired
-    private BrandRepository brandRepository;
+    private static final String LOG_PREFIX = "[BRAND] ";
 
-    /**
-     * {@inheritDoc}
-     */
+    private final BrandRepository brandRepository;
+
     @Override
+    @Cacheable(cacheNames = CacheConfig.BRANDS_CACHE, key = "'" + CacheConfig.BRANDS_ALL_KEY + "'", sync = true)
     public List<Brand> getAllBrands() {
+        log.debug("{}cache miss - loading all brands from repository", LOG_PREFIX);
         return brandRepository.findAll();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
+    @Cacheable(
+            cacheNames = CacheConfig.BRANDS_CACHE,
+            key = "#id",
+            condition = "#id != null",
+            unless = "#result == null")
     public Optional<Brand> getBrandById(Long id) {
+        log.debug("{}cache miss - loading brand id={} from repository", LOG_PREFIX, id);
         return brandRepository.findById(id);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConfig.BRANDS_CACHE, key = "'" + CacheConfig.BRANDS_ALL_KEY + "'"),
+            @CacheEvict(cacheNames = CacheConfig.BRANDS_CACHE, key = "#brand.id", condition = "#brand.id != null")
+    })
     public Brand saveBrand(Brand brand) {
+        log.info("{}saveBrand id={} - evicting cache entries", LOG_PREFIX, brand.getId());
         return brandRepository.save(brand);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConfig.BRANDS_CACHE, key = "'" + CacheConfig.BRANDS_ALL_KEY + "'"),
+            @CacheEvict(cacheNames = CacheConfig.BRANDS_CACHE, key = "#id")
+    })
     public void deleteBrand(Long id) {
+        log.info("{}deleteBrand id={} - evicting cache entries", LOG_PREFIX, id);
         brandRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/service/SalesService.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/SalesService.java
@@ -1,8 +1,8 @@
 package com.septeo.ulyses.technical.test.service;
 
-import com.septeo.ulyses.technical.test.entity.Brand;
+import com.septeo.ulyses.technical.test.dto.BestSellingVehicleResponse;
+import com.septeo.ulyses.technical.test.dto.PageResponse;
 import com.septeo.ulyses.technical.test.entity.Sales;
-import com.septeo.ulyses.technical.test.entity.Vehicle;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,12 +13,7 @@ import java.util.Optional;
  */
 public interface SalesService {
 
-    /**
-     * Get all sales.
-     *
-     * @return a list of all sales
-     */
-    List<Sales> getAllSales();
+    PageResponse<Sales> getSalesPage(int page, int pageSize);
 
     /**
      * Get a sales by its ID.
@@ -28,4 +23,9 @@ public interface SalesService {
      */
     Optional<Sales> getSalesById(Long id);
 
+    List<Sales> getSalesByBrand(Long brandId);
+
+    List<Sales> getSalesByVehicle(Long vehicleId);
+
+    List<BestSellingVehicleResponse> getBestSellingVehicles(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/service/SalesServiceImpl.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/SalesServiceImpl.java
@@ -1,31 +1,48 @@
 package com.septeo.ulyses.technical.test.service;
 
+import com.septeo.ulyses.technical.test.dto.BestSellingVehicleResponse;
+import com.septeo.ulyses.technical.test.dto.PageResponse;
 import com.septeo.ulyses.technical.test.entity.Sales;
+import com.septeo.ulyses.technical.test.entity.Vehicle;
 import com.septeo.ulyses.technical.test.repository.SalesRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.septeo.ulyses.technical.test.service.bestselling.SaleFilters;
+import com.septeo.ulyses.technical.test.service.bestselling.TopKSelector;
+import com.septeo.ulyses.technical.test.service.bestselling.VehicleSalesCount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Implementation of the SalesService interface.
  * This class provides the implementation for all sales-related operations.
  */
 @Service
-@Transactional(readOnly = false)
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
 public class SalesServiceImpl implements SalesService {
 
-    @Autowired
-    private SalesRepository salesRepository;
+    private static final String LOG_PREFIX = "[SALES] ";
+    private static final int TOP_K_BEST_SELLING = 5;
 
-    /**
-     * {@inheritDoc}
-     */
+    private final SalesRepository salesRepository;
+
     @Override
-    public List<Sales> getAllSales() {
-        return salesRepository.findAll();
+    public PageResponse<Sales> getSalesPage(int page, int pageSize) {
+        log.debug("{}getSalesPage page={} pageSize={}", LOG_PREFIX, page, pageSize);
+        final List<Sales> rows = salesRepository.findPage(page, pageSize);
+        final boolean hasMore = rows.size() > pageSize;
+        final List<Sales> data = hasMore ? rows.subList(0, pageSize) : rows;
+
+        return PageResponse.of(data, page, pageSize, hasMore);
     }
 
     /**
@@ -33,7 +50,59 @@ public class SalesServiceImpl implements SalesService {
      */
     @Override
     public Optional<Sales> getSalesById(Long id) {
+        log.debug("{}getSalesById id={}", LOG_PREFIX, id);
         return salesRepository.findById(id);
     }
 
+    @Override
+    public List<Sales> getSalesByBrand(Long brandId) {
+        log.debug("{}getSalesByBrand brandId={}", LOG_PREFIX, brandId);
+        return salesRepository.findByBrandId(brandId);
+    }
+
+    @Override
+    public List<Sales> getSalesByVehicle(Long vehicleId) {
+        log.debug("{}getSalesByVehicle vehicleId={}", LOG_PREFIX, vehicleId);
+        return salesRepository.findByVehicleId(vehicleId);
+    }
+
+    @Override
+    public List<BestSellingVehicleResponse> getBestSellingVehicles(LocalDate startDate, LocalDate endDate) {
+        log.info("{}getBestSellingVehicles startDate={} endDate={}", LOG_PREFIX, startDate, endDate);
+        final Predicate<Sales> filter = SaleFilters.byStartDate(startDate)
+                .and(SaleFilters.byEndDate(endDate));
+
+        final List<Sales> all = salesRepository.findAll();
+        final List<VehicleSalesCount> counts = countSalesByVehicle(all, filter);
+        final List<VehicleSalesCount> top = TopKSelector.of(counts, TOP_K_BEST_SELLING, VehicleSalesCount::totalSales);
+        log.debug("{}getBestSellingVehicles scanned={} distinctVehicles={} returned={}",
+                LOG_PREFIX, all.size(), counts.size(), top.size());
+        return top.stream().map(this::toResponse).toList();
+    }
+
+    private List<VehicleSalesCount> countSalesByVehicle(List<Sales> sales, Predicate<Sales> filter) {
+        // LinkedHashMap keeps first-seen vehicle order, which is the tie-break contract for top-K.
+        final Map<Long, VehicleSalesCount> byVehicle = new LinkedHashMap<>();
+        for (Sales sale : sales) {
+            if (!filter.test(sale)) {
+                continue;
+            }
+            final Vehicle vehicle = sale.getVehicle();
+            byVehicle.merge(
+                    vehicle.getId(),
+                    new VehicleSalesCount(vehicle, 1L),
+                    (existing, fresh) -> new VehicleSalesCount(existing.vehicle(), existing.totalSales() + 1L));
+        }
+        return List.copyOf(byVehicle.values());
+    }
+
+    private BestSellingVehicleResponse toResponse(VehicleSalesCount count) {
+        final Vehicle vehicle = count.vehicle();
+        return new BestSellingVehicleResponse(
+                vehicle.getId(),
+                vehicle.getBrand().getName(),
+                vehicle.getModel(),
+                vehicle.getYear(),
+                count.totalSales());
+    }
 }

--- a/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/SaleFilters.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/SaleFilters.java
@@ -1,0 +1,25 @@
+package com.septeo.ulyses.technical.test.service.bestselling;
+
+import com.septeo.ulyses.technical.test.entity.Sales;
+import lombok.experimental.UtilityClass;
+
+import java.time.LocalDate;
+import java.util.function.Predicate;
+
+@UtilityClass
+public final class SaleFilters {
+
+    public static Predicate<Sales> byStartDate(LocalDate startDate) {
+        if (startDate == null) {
+            return sale -> true;
+        }
+        return sale -> !sale.getSaleDate().isBefore(startDate);
+    }
+
+    public static Predicate<Sales> byEndDate(LocalDate endDate) {
+        if (endDate == null) {
+            return sale -> true;
+        }
+        return sale -> !sale.getSaleDate().isAfter(endDate);
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/TopKSelector.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/TopKSelector.java
@@ -1,0 +1,102 @@
+package com.septeo.ulyses.technical.test.service.bestselling;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.ToLongFunction;
+
+/**
+ * Selects the top-K elements of a collection without using any built-in
+ * sorting facility (no {@code Comparator}, no {@code Collections.sort},
+ * no {@code Stream.sorted}).
+ *
+ * <p>Internally keeps a small sorted buffer of size {@code k}. Each candidate
+ * is fast-rejected against the current minimum (threshold) once the buffer
+ * is full, so the algorithm scales linearly with the input size for small
+ * {@code k} values, which is the expected scenario (top 5).
+ */
+@UtilityClass
+public final class TopKSelector {
+
+    public static <T> List<T> of(Collection<T> items, int k, ToLongFunction<? super T> valueExtractor) {
+        if (items == null || items.isEmpty() || k <= 0) {
+            return List.of();
+        }
+
+        final RankedBuffer<T> buffer = new RankedBuffer<>(Math.min(k, items.size()));
+        items.forEach(item -> buffer.offer(item, valueExtractor.applyAsLong(item)));
+        return buffer.toList();
+    }
+
+    private static final class RankedBuffer<T> {
+
+        private final Object[] items;
+        private final long[] values;
+        private final int capacity;
+        private int size;
+        private long threshold;
+
+        RankedBuffer(int capacity) {
+            this.capacity = capacity;
+            this.items = new Object[capacity];
+            this.values = new long[capacity];
+            this.size = 0;
+            this.threshold = Long.MIN_VALUE;
+        }
+
+        void offer(T item, long value) {
+            if (isRejected(value)) {
+                return;
+            }
+            final int position = findInsertPosition(value);
+            shiftRight(position);
+            place(item, value, position);
+        }
+
+        private boolean isRejected(long value) {
+            return size == capacity && value <= threshold;
+        }
+
+        private int findInsertPosition(long value) {
+            int pos = lastWritableIndex();
+            while (pos > 0 && values[pos - 1] < value) {
+                pos--;
+            }
+            return pos;
+        }
+
+        private void shiftRight(int fromPosition) {
+            final int length = lastWritableIndex() - fromPosition;
+            if (length > 0) {
+                System.arraycopy(values, fromPosition, values, fromPosition + 1, length);
+                System.arraycopy(items, fromPosition, items, fromPosition + 1, length);
+            }
+        }
+
+        private void place(T item, long value, int position) {
+            items[position] = item;
+            values[position] = value;
+            if (size < capacity) {
+                size++;
+            }
+            if (size == capacity) {
+                threshold = values[capacity - 1];
+            }
+        }
+
+        private int lastWritableIndex() {
+            return (size < capacity) ? size : capacity - 1;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<T> toList() {
+            final List<T> result = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                result.add((T) items[i]);
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/VehicleSalesCount.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/service/bestselling/VehicleSalesCount.java
@@ -1,0 +1,6 @@
+package com.septeo.ulyses.technical.test.service.bestselling;
+
+import com.septeo.ulyses.technical.test.entity.Vehicle;
+
+public record VehicleSalesCount(Vehicle vehicle, long totalSales) {
+}

--- a/src/main/java/com/septeo/ulyses/technical/test/validation/RequestValidations.java
+++ b/src/main/java/com/septeo/ulyses/technical/test/validation/RequestValidations.java
@@ -1,0 +1,45 @@
+package com.septeo.ulyses.technical.test.validation;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/**
+ * Lightweight request-parameter validations.
+ *
+ * <p>Each method throws {@link ResponseStatusException} with status 400 when the
+ * precondition is violated. Kept as a utility class to avoid pulling in any
+ * external validation library (as required by the technical test) while keeping
+ * controllers free of boilerplate.
+ *
+ * <p><b>Design note:</b> A declarative approach (Bean Validation with {@code @Min},
+ * {@code @Positive}, etc.) would be preferred in a production codebase, but it is
+ * intentionally avoided here to respect the "no external libraries" constraint.
+ * For the current scope (a handful of endpoints with simple, stateless checks),
+ * this utility offers the best trade-off between readability, testability and
+ * cost of ownership.
+ */
+@UtilityClass
+public class RequestValidations {
+
+    public static void positive(Long value, String fieldName) {
+        if (value == null || value <= 0) {
+            throw new ResponseStatusException(BAD_REQUEST, "%s must be a positive number".formatted(fieldName));
+        }
+    }
+
+    public static void minimum(int value, int min, String fieldName) {
+        if (value < min) {
+            throw new ResponseStatusException(BAD_REQUEST, "%s must be >= %d".formatted(fieldName, min));
+        }
+    }
+
+    public static void dateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new ResponseStatusException(BAD_REQUEST, "startDate must be before or equal to endDate");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,9 +11,33 @@ spring.h2.console.path=/h2-console
 # JPA Configuration
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
 # SQL Initialization
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
+
+# Access log file path (used by logback-spring.xml)
+app.access-log.file=logs/access.log
+
+# Brand cache TTL in seconds
+app.cache.brands.ttl-seconds=60
+
+# Security credentials (DEMO ONLY — production must override via env vars / secret manager)
+app.security.user.username=${APP_SECURITY_USER_USERNAME:user}
+app.security.user.password=${APP_SECURITY_USER_PASSWORD:user}
+app.security.admin.username=${APP_SECURITY_ADMIN_USERNAME:admin}
+app.security.admin.password=${APP_SECURITY_ADMIN_PASSWORD:admin}
+
+# Logging levels
+# Per-package overrides can be set via env (e.g. LOGGING_LEVEL_COM_SEPTEO_ULYSES_TECHNICAL_TEST_CACHE=DEBUG)
+logging.level.root=INFO
+logging.level.com.septeo.ulyses.technical.test=INFO
+logging.level.com.septeo.ulyses.technical.test.cache=INFO
+logging.level.com.septeo.ulyses.technical.test.controller=INFO
+logging.level.com.septeo.ulyses.technical.test.service=INFO
+logging.level.com.septeo.ulyses.technical.test.repository=INFO
+logging.level.org.springframework.web=INFO
+logging.level.org.springframework.security=INFO
+logging.level.org.hibernate.SQL=WARN

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty name="ACCESS_LOG_FILE"
+                    source="app.access-log.file"
+                    defaultValue="logs/access.log"/>
+
+    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${ACCESS_LOG_FILE}</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.septeo.ulyses.technical.test.logging.AccessLogFilter"
+            level="INFO"
+            additivity="false">
+        <appender-ref ref="ACCESS_LOG_FILE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/com/septeo/ulyses/technical/test/cache/CacheEntryTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/cache/CacheEntryTest.java
@@ -1,0 +1,37 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CacheEntryTest {
+
+    @Test
+    @DisplayName("isExpired returns true when expiresAt is in the past")
+    void test_isExpired_1() {
+        // Given
+        final CacheEntry entry = new CacheEntry("value", Instant.now().minusSeconds(1));
+
+        // When
+        final boolean expired = entry.isExpired();
+
+        // Then
+        assertThat(expired).isTrue();
+    }
+
+    @Test
+    @DisplayName("isExpired returns false when expiresAt is in the future")
+    void test_isExpired_2() {
+        // Given
+        final CacheEntry entry = new CacheEntry("value", Instant.now().plusSeconds(60));
+
+        // When
+        final boolean expired = entry.isExpired();
+
+        // Then
+        assertThat(expired).isFalse();
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/cache/TtlCacheManagerTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/cache/TtlCacheManagerTest.java
@@ -1,0 +1,68 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+
+class TtlCacheManagerTest {
+
+    @Test
+    @DisplayName("getCache creates a TtlCache on the first request")
+    void test_getCache_1() {
+        // Given
+        final TtlCacheManager manager = new TtlCacheManager(Duration.ofSeconds(30));
+
+        // When
+        final Cache cache = manager.getCache("brands");
+
+        // Then
+        assertThat(cache).isInstanceOf(TtlCache.class);
+        assertThat(cache.getName()).isEqualTo("brands");
+    }
+
+    @Test
+    @DisplayName("getCache returns the same instance for repeated lookups")
+    void test_getCache_2() {
+        // Given
+        final TtlCacheManager manager = new TtlCacheManager(Duration.ofSeconds(30));
+
+        // When
+        final Cache first = manager.getCache("brands");
+        final Cache second = manager.getCache("brands");
+
+        // Then
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    @DisplayName("getCacheNames is empty until a cache is requested")
+    void test_getCacheNames_1() {
+        // Given
+        final TtlCacheManager manager = new TtlCacheManager(Duration.ofSeconds(30));
+
+        // When
+        final var names = manager.getCacheNames();
+
+        // Then
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getCacheNames returns every cache that has been requested")
+    void test_getCacheNames_2() {
+        // Given
+        final TtlCacheManager manager = new TtlCacheManager(Duration.ofSeconds(30));
+        manager.getCache("brands");
+        manager.getCache("vehicles");
+
+        // When
+        final var names = manager.getCacheNames();
+
+        // Then
+        assertThat(names).containsExactlyInAnyOrder("brands", "vehicles");
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/cache/TtlCacheTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/cache/TtlCacheTest.java
@@ -1,0 +1,358 @@
+package com.septeo.ulyses.technical.test.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueRetrievalException;
+
+class TtlCacheTest {
+
+    private static final String CACHE_NAME = "test-cache";
+    private static final Duration LONG_TTL = Duration.ofMinutes(5);
+    private static final Duration EXPIRED_TTL = Duration.ofMillis(-1);
+
+    @Test
+    @DisplayName("getName returns the cache name")
+    void test_getName_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+
+        // When
+        final String name = cache.getName();
+
+        // Then
+        assertThat(name).isEqualTo(CACHE_NAME);
+    }
+
+    @Test
+    @DisplayName("getNativeCache returns the underlying concurrent map")
+    void test_getNativeCache_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+
+        // When
+        final Object nativeCache = cache.getNativeCache();
+
+        // Then
+        assertThat(nativeCache).isNotNull();
+    }
+
+    @Test
+    @DisplayName("get(key) returns null when the entry is not present")
+    void test_get_key_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+
+        // When
+        final Cache.ValueWrapper wrapper = cache.get("missing");
+
+        // Then
+        assertThat(wrapper).isNull();
+    }
+
+    @Test
+    @DisplayName("get(key) returns the value wrapped after a put")
+    void test_get_key_2() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", "value");
+
+        // When
+        final Cache.ValueWrapper wrapper = cache.get("k");
+
+        // Then
+        assertThat(wrapper).isNotNull();
+        assertThat(wrapper.get()).isEqualTo("value");
+    }
+
+    @Test
+    @DisplayName("get(key) returns null and evicts expired entries")
+    void test_get_key_3() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, EXPIRED_TTL);
+        cache.put("k", "value");
+
+        // When
+        final Cache.ValueWrapper wrapper = cache.get("k");
+
+        // Then
+        assertThat(wrapper).isNull();
+    }
+
+    @Test
+    @DisplayName("get(key, type) returns null for missing entry")
+    void test_get_key_type_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+
+        // When
+        final String value = cache.get("missing", String.class);
+
+        // Then
+        assertThat(value).isNull();
+    }
+
+    @Test
+    @DisplayName("get(key, type) returns the cached value when type matches")
+    void test_get_key_type_2() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", "hello");
+
+        // When
+        final String value = cache.get("k", String.class);
+
+        // Then
+        assertThat(value).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("get(key, type) returns the value when type is null")
+    void test_get_key_type_3() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", "value");
+
+        // When
+        final Object value = cache.get("k", (Class<Object>) null);
+
+        // Then
+        assertThat(value).isEqualTo("value");
+    }
+
+    @Test
+    @DisplayName("get(key, type) returns null when value is null even with a type")
+    void test_get_key_type_4() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", null);
+
+        // When
+        final String value = cache.get("k", String.class);
+
+        // Then
+        assertThat(value).isNull();
+    }
+
+    @Test
+    @DisplayName("get(key, type) throws when the cached value does not match the requested type")
+    void test_get_key_type_5() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", 42);
+
+        // When & Then
+        assertThatThrownBy(() -> cache.get("k", String.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(String.class.getName());
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) loads and caches the value on first access")
+    void test_get_key_callable_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        final AtomicInteger loaderCalls = new AtomicInteger();
+        final Callable<String> loader = () -> {
+            loaderCalls.incrementAndGet();
+            return "loaded";
+        };
+
+        // When
+        final String first = cache.get("k", loader);
+        final String second = cache.get("k", loader);
+
+        // Then
+        assertThat(first).isEqualTo("loaded");
+        assertThat(second).isEqualTo("loaded");
+        assertThat(loaderCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) reloads when the entry is expired")
+    void test_get_key_callable_2() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, EXPIRED_TTL);
+        final AtomicInteger loaderCalls = new AtomicInteger();
+        final Callable<String> loader = () -> "value-" + loaderCalls.incrementAndGet();
+
+        // When
+        final String first = cache.get("k", loader);
+        final String second = cache.get("k", loader);
+
+        // Then
+        assertThat(first).isEqualTo("value-1");
+        assertThat(second).isEqualTo("value-2");
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) wraps loader exceptions into ValueRetrievalException")
+    void test_get_key_callable_3() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        final RuntimeException cause = new RuntimeException("boom");
+        final Callable<String> loader = () -> {
+            throw cause;
+        };
+
+        // When & Then
+        assertThatThrownBy(() -> cache.get("k", loader))
+                .isInstanceOf(ValueRetrievalException.class)
+                .hasCause(cause);
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) only runs the loader once under concurrent access")
+    void test_get_key_callable_4() throws Exception {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        final int threads = 16;
+        final AtomicInteger loaderCalls = new AtomicInteger();
+        final CyclicBarrier barrier = new CyclicBarrier(threads);
+        final CountDownLatch finished = new CountDownLatch(threads);
+        final Callable<String> loader = () -> {
+            loaderCalls.incrementAndGet();
+            Thread.sleep(20);
+            return "single";
+        };
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+        // When
+        final List<Future<String>> futures = new java.util.ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                try {
+                    barrier.await();
+                    return cache.get("k", loader);
+                } finally {
+                    finished.countDown();
+                }
+            }));
+        }
+        assertThat(finished.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Then
+        for (Future<String> f : futures) {
+            assertThat(f.get()).isEqualTo("single");
+        }
+        assertThat(loaderCalls.get()).isEqualTo(1);
+        pool.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) does not block operations on other keys while a slow loader runs")
+    void test_get_key_callable_5() throws Exception {
+        // Given - a slow loader on key "slow" must not freeze a concurrent put/get on key "fast"
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        final CountDownLatch loaderStarted = new CountDownLatch(1);
+        final CountDownLatch otherKeyDone = new CountDownLatch(1);
+        final Callable<String> slowLoader = () -> {
+            loaderStarted.countDown();
+            // Wait for the other key to complete; if the bucket were locked this would deadlock.
+            if (!otherKeyDone.await(2, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("other key was blocked by the slow loader");
+            }
+            return "slow-value";
+        };
+        final ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        // When
+        final Future<String> slow = pool.submit(() -> cache.get("slow", slowLoader));
+        assertThat(loaderStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        cache.put("fast", "fast-value");
+        final Cache.ValueWrapper fast = cache.get("fast");
+        otherKeyDone.countDown();
+
+        // Then
+        assertThat(fast).isNotNull();
+        assertThat(fast.get()).isEqualTo("fast-value");
+        assertThat(slow.get(2, TimeUnit.SECONDS)).isEqualTo("slow-value");
+        pool.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("get(key, Callable) propagates ValueRetrievalException to concurrent waiters when the loader fails")
+    void test_get_key_callable_6() throws Exception {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        final CountDownLatch loaderStarted = new CountDownLatch(1);
+        final CountDownLatch followerReady = new CountDownLatch(1);
+        final RuntimeException boom = new RuntimeException("boom");
+        final Callable<String> failing = () -> {
+            loaderStarted.countDown();
+            followerReady.await();
+            throw boom;
+        };
+        final ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        // When
+        final Future<String> leader = pool.submit(() -> cache.get("k", failing));
+        assertThat(loaderStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        final Future<String> follower = pool.submit(() -> cache.get("k", failing));
+        // Give the follower a moment to register on the in-flight future before releasing the loader.
+        Thread.sleep(50);
+        followerReady.countDown();
+
+        // Then
+        assertThatThrownBy(leader::get)
+                .hasCauseInstanceOf(Cache.ValueRetrievalException.class);
+        assertThatThrownBy(follower::get)
+                .hasCauseInstanceOf(Cache.ValueRetrievalException.class);
+        pool.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("evict removes the cached entry")
+    void test_evict_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("k", "value");
+
+        // When
+        cache.evict("k");
+
+        // Then
+        assertThat(cache.get("k")).isNull();
+    }
+
+    @Test
+    @DisplayName("evict on missing key does not throw")
+    void test_evict_2() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+
+        // When & Then
+        assertThatCode(() -> cache.evict("missing")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("clear removes all cached entries")
+    void test_clear_1() {
+        // Given
+        final TtlCache cache = new TtlCache(CACHE_NAME, LONG_TTL);
+        cache.put("a", 1);
+        cache.put("b", 2);
+
+        // When
+        cache.clear();
+
+        // Then
+        assertThat(cache.get("a")).isNull();
+        assertThat(cache.get("b")).isNull();
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/controller/SalesControllerTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/controller/SalesControllerTest.java
@@ -1,0 +1,265 @@
+package com.septeo.ulyses.technical.test.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import com.septeo.ulyses.technical.test.dto.BestSellingVehicleResponse;
+import com.septeo.ulyses.technical.test.dto.PageResponse;
+import com.septeo.ulyses.technical.test.dto.PaginationInfo;
+import com.septeo.ulyses.technical.test.entity.Sales;
+import com.septeo.ulyses.technical.test.service.SalesService;
+import com.septeo.ulyses.technical.test.validation.RequestValidations;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class SalesControllerTest {
+
+    private static final int PAGE_SIZE = 10;
+    private static final int MIN_PAGE = 1;
+
+    @Mock
+    private SalesService salesService;
+
+    @InjectMocks
+    private SalesController subject;
+
+    @Test
+    @DisplayName("getAllSales validates page minimum and returns the service page")
+    void test_getAllSales_1() {
+        // Given
+        final PageResponse<Sales> page = new PageResponse<>(List.of(new Sales()), new PaginationInfo(false, 3, PAGE_SIZE));
+        when(this.salesService.getSalesPage(3, PAGE_SIZE)).thenReturn(page);
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<PageResponse<Sales>> response = this.subject.getAllSales(3);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isSameAs(page);
+            validations.verify(() -> RequestValidations.minimum(3, MIN_PAGE, "page"));
+        }
+    }
+
+    @Test
+    @DisplayName("getAllSales propagates the 400 raised by the page validator")
+    void test_getAllSales_2() {
+        // Given
+        final ResponseStatusException failure = new ResponseStatusException(HttpStatus.BAD_REQUEST, "boom");
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            validations.when(() -> RequestValidations.minimum(0, MIN_PAGE, "page")).thenThrow(failure);
+
+            // When & Then
+            assertThatThrownBy(() -> this.subject.getAllSales(0)).isSameAs(failure);
+            verifyNoInteractions(this.salesService);
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesById validates id, returns 200 when present")
+    void test_getSalesById_1() {
+        // Given
+        final Sales sale = new Sales();
+        when(this.salesService.getSalesById(5L)).thenReturn(Optional.of(sale));
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<Sales> response = this.subject.getSalesById(5L);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isSameAs(sale);
+            validations.verify(() -> RequestValidations.positive(5L, "id"));
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesById returns 404 when the sale is not found")
+    void test_getSalesById_2() {
+        // Given
+        when(this.salesService.getSalesById(99L)).thenReturn(Optional.empty());
+
+        try (MockedStatic<RequestValidations> ignored = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<Sales> response = this.subject.getSalesById(99L);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody()).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesById propagates the validation error and skips the service")
+    void test_getSalesById_3() {
+        // Given
+        final ResponseStatusException failure = new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad");
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            validations.when(() -> RequestValidations.positive(-1L, "id")).thenThrow(failure);
+
+            // When & Then
+            assertThatThrownBy(() -> this.subject.getSalesById(-1L)).isSameAs(failure);
+            verifyNoInteractions(this.salesService);
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesByBrand validates brandId and returns the sales list")
+    void test_getSalesByBrand_1() {
+        // Given
+        final List<Sales> expected = List.of(new Sales());
+        when(this.salesService.getSalesByBrand(7L)).thenReturn(expected);
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<List<Sales>> response = this.subject.getSalesByBrand(7L);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isSameAs(expected);
+            validations.verify(() -> RequestValidations.positive(7L, "brandId"));
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesByBrand propagates validation error and skips the service")
+    void test_getSalesByBrand_2() {
+        // Given
+        final ResponseStatusException failure = new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad");
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            validations.when(() -> RequestValidations.positive(0L, "brandId")).thenThrow(failure);
+
+            // When & Then
+            assertThatThrownBy(() -> this.subject.getSalesByBrand(0L)).isSameAs(failure);
+            verifyNoInteractions(this.salesService);
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesByVehicle validates vehicleId and returns the sales list")
+    void test_getSalesByVehicle_1() {
+        // Given
+        final List<Sales> expected = List.of(new Sales(), new Sales());
+        when(this.salesService.getSalesByVehicle(4L)).thenReturn(expected);
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<List<Sales>> response = this.subject.getSalesByVehicle(4L);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isSameAs(expected);
+            validations.verify(() -> RequestValidations.positive(4L, "vehicleId"));
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesByVehicle propagates validation error and skips the service")
+    void test_getSalesByVehicle_2() {
+        // Given
+        final ResponseStatusException failure = new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad");
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            validations.when(() -> RequestValidations.positive(0L, "vehicleId")).thenThrow(failure);
+
+            // When & Then
+            assertThatThrownBy(() -> this.subject.getSalesByVehicle(0L)).isSameAs(failure);
+            verifyNoInteractions(this.salesService);
+        }
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles validates the date range and returns the service result")
+    void test_getBestSellingVehicles_1() {
+        // Given
+        final LocalDate startDate = LocalDate.of(2024, 1, 1);
+        final LocalDate endDate = LocalDate.of(2024, 12, 31);
+        final List<BestSellingVehicleResponse> expected =
+                List.of(new BestSellingVehicleResponse(1L, "Brand", "Model", "2024", 10L));
+        when(this.salesService.getBestSellingVehicles(startDate, endDate)).thenReturn(expected);
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<List<BestSellingVehicleResponse>> response =
+                    this.subject.getBestSellingVehicles(startDate, endDate);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isSameAs(expected);
+            validations.verify(() -> RequestValidations.dateRange(startDate, endDate));
+        }
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles accepts null date filters")
+    void test_getBestSellingVehicles_2() {
+        // Given
+        when(this.salesService.getBestSellingVehicles(null, null)).thenReturn(List.of());
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<List<BestSellingVehicleResponse>> response =
+                    this.subject.getBestSellingVehicles(null, null);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEmpty();
+            validations.verify(() -> RequestValidations.dateRange(null, null));
+        }
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles propagates the 400 raised by the date-range validator")
+    void test_getBestSellingVehicles_3() {
+        // Given
+        final LocalDate startDate = LocalDate.of(2024, 12, 31);
+        final LocalDate endDate = LocalDate.of(2024, 1, 1);
+        final ResponseStatusException failure = new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad");
+
+        try (MockedStatic<RequestValidations> validations = mockStatic(RequestValidations.class)) {
+            validations.when(() -> RequestValidations.dateRange(startDate, endDate)).thenThrow(failure);
+
+            // When & Then
+            assertThatThrownBy(() -> this.subject.getBestSellingVehicles(startDate, endDate)).isSameAs(failure);
+            verifyNoInteractions(this.salesService);
+        }
+    }
+
+    @Test
+    @DisplayName("getSalesByBrand returns an empty list when there are no sales")
+    void test_getSalesByBrand_3() {
+        // Given
+        when(this.salesService.getSalesByBrand(1L)).thenReturn(List.of());
+
+        try (MockedStatic<RequestValidations> ignored = mockStatic(RequestValidations.class)) {
+            // When
+            final ResponseEntity<List<Sales>> response = this.subject.getSalesByBrand(1L);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEmpty();
+            verify(this.salesService).getSalesByBrand(1L);
+        }
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/dto/PageResponseTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/dto/PageResponseTest.java
@@ -1,0 +1,42 @@
+package com.septeo.ulyses.technical.test.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PageResponseTest {
+
+    @Test
+    @DisplayName("of builds a PageResponse with the provided data and pagination info")
+    void test_of_1() {
+        // Given
+        final List<String> data = List.of("a", "b", "c");
+        final int page = 2;
+        final int pageSize = 3;
+        final boolean hasMore = true;
+
+        // When
+        final PageResponse<String> response = PageResponse.of(data, page, pageSize, hasMore);
+
+        // Then
+        assertThat(response.data()).isSameAs(data);
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(true, page, pageSize));
+    }
+
+    @Test
+    @DisplayName("of supports empty data and hasMore=false")
+    void test_of_2() {
+        // Given
+        final List<String> data = List.of();
+
+        // When
+        final PageResponse<String> response = PageResponse.of(data, 1, 10, false);
+
+        // Then
+        assertThat(response.data()).isEmpty();
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(false, 1, 10));
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/BrandCacheIT.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/BrandCacheIT.java
@@ -1,0 +1,277 @@
+package com.septeo.ulyses.technical.test.it;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.septeo.ulyses.technical.test.config.CacheConfig;
+import com.septeo.ulyses.technical.test.controller.BrandController;
+import com.septeo.ulyses.technical.test.entity.Brand;
+import com.septeo.ulyses.technical.test.it.slice.controller.BrandControllerSlice;
+import com.septeo.ulyses.technical.test.it.slice.infra.CacheConfigSlice;
+import com.septeo.ulyses.technical.test.it.slice.infra.JpaSlice;
+import com.septeo.ulyses.technical.test.it.slice.infra.SecuritySlice;
+import com.septeo.ulyses.technical.test.it.slice.repository.BrandRepositorySlice;
+import com.septeo.ulyses.technical.test.it.slice.service.BrandServiceSlice;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// DB restore: @Transactional rolls back every test method, so writes against the H2 instance never
+// persist beyond the test boundary and data.sql state is reset for the next one.
+@ActiveProfiles("test")
+@WebMvcTest(controllers = BrandController.class)
+@ContextConfiguration(classes = {
+        BrandControllerSlice.class,
+        BrandServiceSlice.class,
+        BrandRepositorySlice.class,
+        CacheConfigSlice.class,
+        SecuritySlice.class,
+        JpaSlice.class
+})
+@Transactional
+@DisplayName("BrandController + cache IT - controller → service (cache) → repository → H2 with security filters enabled")
+class BrandCacheIT {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Autowired
+    private MockMvc api;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Cache brandsCache;
+
+    @BeforeEach
+    void cleanCache() {
+        brandsCache = cacheManager.getCache(CacheConfig.BRANDS_CACHE);
+        brandsCache.clear();
+    }
+
+    @Test
+    @DisplayName("test_getAllBrands_1: returns the 3 brands seeded by data.sql and populates cache")
+    void test_getAllBrands_1() throws Exception {
+        // When
+        api.perform(get("/api/brands"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(3)));
+
+        // Then
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("test_getAllBrands_2: second call is served from cache (repository not used)")
+    void test_getAllBrands_2() throws Exception {
+        // Given
+        api.perform(get("/api/brands")).andExpect(status().isOk());
+        @SuppressWarnings("unchecked")
+        List<Brand> cached = (List<Brand>) brandsCache.get(CacheConfig.BRANDS_ALL_KEY).get();
+        Brand sentinel = new Brand(999L, "SENTINEL", "from-cache", List.of());
+        brandsCache.put(CacheConfig.BRANDS_ALL_KEY, List.of(sentinel));
+
+        // When & Then
+        api.perform(get("/api/brands"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].name", is("SENTINEL")));
+
+        // Restore
+        brandsCache.put(CacheConfig.BRANDS_ALL_KEY, cached);
+    }
+
+    @Test
+    @DisplayName("test_getBrandById_1: caches the entry under its id key")
+    void test_getBrandById_1() throws Exception {
+        // When
+        api.perform(get("/api/brands/{id}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)));
+
+        // Then
+        assertThat(brandsCache.get(1L)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("test_getBrandById_2: unknown id returns 404 (Optional.empty bypasses cache write)")
+    void test_getBrandById_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/brands/{id}", 9_999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("test_createBrand_1: persists to DB and evicts the 'all' cache entry")
+    void test_createBrand_1() throws Exception {
+        // Given
+        api.perform(get("/api/brands")).andExpect(status().isOk());
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNotNull();
+        Brand toCreate = new Brand(null, "Peugeot", "French manufacturer", List.of());
+
+        // When
+        api.perform(post("/api/brands")
+                        .with(httpBasic("admin", "admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(toCreate)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name", is("Peugeot")));
+
+        // Then
+        entityManager.flush();
+        Integer rows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM brands WHERE name = ?", Integer.class, "Peugeot");
+        assertThat(rows).isEqualTo(1);
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNull();
+        // Restore: @Transactional rolls back the inserted row.
+    }
+
+    @Test
+    @DisplayName("test_updateBrand_1: updates DB row and evicts both 'all' and id keys")
+    void test_updateBrand_1() throws Exception {
+        // Given
+        String created = api.perform(post("/api/brands")
+                        .with(httpBasic("admin", "admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(new Brand(null, "Skoda", "new", List.of()))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long target = JSON.readTree(created).get("id").asLong();
+        api.perform(get("/api/brands")).andExpect(status().isOk());
+        api.perform(get("/api/brands/{id}", target)).andExpect(status().isOk());
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNotNull();
+        assertThat(brandsCache.get(target)).isNotNull();
+        Brand update = new Brand(null, "Skoda-Updated", "edited", List.of());
+
+        // When
+        api.perform(put("/api/brands/{id}", target)
+                        .with(httpBasic("admin", "admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("Skoda-Updated")));
+
+        // Then
+        entityManager.flush();
+        String name = jdbc.queryForObject(
+                "SELECT name FROM brands WHERE id = ?", String.class, target);
+        assertThat(name).isEqualTo("Skoda-Updated");
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNull();
+        assertThat(brandsCache.get(target)).isNull();
+        // Restore: @Transactional rolls back the insert and the update.
+    }
+
+    @Test
+    @DisplayName("test_updateBrand_2: unknown id returns 404 and does not touch DB")
+    void test_updateBrand_2() throws Exception {
+        // Given
+        Brand update = new Brand(null, "x", "x", List.of());
+
+        // When & Then
+        api.perform(put("/api/brands/{id}", 9_999L)
+                        .with(httpBasic("admin", "admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(update)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("test_deleteBrand_1: removes row, evicts caches and subsequent GET returns 404")
+    void test_deleteBrand_1() throws Exception {
+        // Given
+        String created = api.perform(post("/api/brands")
+                        .with(httpBasic("admin", "admin"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(new Brand(null, "Cupra", "new", List.of()))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = JSON.readTree(created);
+        Long target = node.get("id").asLong();
+        api.perform(get("/api/brands")).andExpect(status().isOk());
+        api.perform(get("/api/brands/{id}", target)).andExpect(status().isOk());
+
+        // When
+        api.perform(delete("/api/brands/{id}", target)
+                        .with(httpBasic("admin", "admin")))
+                .andExpect(status().isNoContent());
+
+        // Then
+        entityManager.flush();
+        Integer rows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM brands WHERE id = ?", Integer.class, target);
+        assertThat(rows).isZero();
+        assertThat(brandsCache.get(CacheConfig.BRANDS_ALL_KEY)).isNull();
+        assertThat(brandsCache.get(target)).isNull();
+        // Restore: @Transactional rolls back the insert and the delete.
+    }
+
+    @Test
+    @DisplayName("test_deleteBrand_2: unknown id returns 404")
+    void test_deleteBrand_2() throws Exception {
+        // When & Then
+        api.perform(delete("/api/brands/{id}", 9_999L)
+                        .with(httpBasic("admin", "admin")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("test_security_1: write without credentials returns 401")
+    void test_security_1() throws Exception {
+        // When & Then
+        api.perform(post("/api/brands")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(new Brand(null, "Anon", "x", List.of()))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("test_security_2: write with USER role returns 403")
+    void test_security_2() throws Exception {
+        // When & Then
+        api.perform(delete("/api/brands/{id}", 1L)
+                        .with(httpBasic("user", "user")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("test_security_3: bad credentials return 401")
+    void test_security_3() throws Exception {
+        // When & Then
+        api.perform(put("/api/brands/{id}", 1L)
+                        .with(httpBasic("admin", "wrong"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JSON.writeValueAsString(new Brand(null, "x", "x", List.of()))))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/SalesControllerIT.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/SalesControllerIT.java
@@ -1,0 +1,175 @@
+package com.septeo.ulyses.technical.test.it;
+
+import com.septeo.ulyses.technical.test.controller.SalesController;
+import com.septeo.ulyses.technical.test.it.slice.controller.SalesControllerSlice;
+import com.septeo.ulyses.technical.test.it.slice.infra.JpaSlice;
+import com.septeo.ulyses.technical.test.it.slice.infra.SecuritySlice;
+import com.septeo.ulyses.technical.test.it.slice.repository.SalesRepositorySlice;
+import com.septeo.ulyses.technical.test.it.slice.service.SalesServiceSlice;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// DB restore: @Transactional rolls back every test method, leaving data.sql state untouched between tests.
+@ActiveProfiles("test")
+@WebMvcTest(controllers = SalesController.class)
+@ContextConfiguration(classes = {
+        SalesControllerSlice.class,
+        SalesServiceSlice.class,
+        SalesRepositorySlice.class,
+        SecuritySlice.class,
+        JpaSlice.class
+})
+@Transactional
+@DisplayName("SalesController IT - real DB through controller → service → repository slice with security filters enabled")
+class SalesControllerIT {
+
+    @Autowired
+    private MockMvc api;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("test_getAllSales_1: first page returns 10 sales and hasMore=true")
+    void test_getAllSales_1() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales").param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()", is(10)))
+                .andExpect(jsonPath("$.pagination.page", is(1)))
+                .andExpect(jsonPath("$.pagination.pageSize", is(10)))
+                .andExpect(jsonPath("$.pagination.hasMore", is(true)));
+    }
+
+    @Test
+    @DisplayName("test_getAllSales_2: invalid page <1 returns 400")
+    void test_getAllSales_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales").param("page", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("test_getAllSales_3: default page parameter is 1")
+    void test_getAllSales_3() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pagination.page", is(1)));
+    }
+
+    @Test
+    @DisplayName("test_getSalesById_1: existing id returns 200 and the entity")
+    void test_getSalesById_1() throws Exception {
+        // Given
+        Long anyId = jdbc.queryForObject("SELECT MIN(id) FROM sales", Long.class);
+
+        // When & Then
+        api.perform(get("/api/sales/{id}", anyId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(anyId.intValue())));
+    }
+
+    @Test
+    @DisplayName("test_getSalesById_2: unknown id returns 404")
+    void test_getSalesById_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/{id}", 9_999_999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("test_getSalesById_3: non-positive id returns 400")
+    void test_getSalesById_3() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/{id}", 0L))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("test_getSalesByBrand_1: existing brand returns matching sales count")
+    void test_getSalesByBrand_1() throws Exception {
+        // Given
+        Integer expected = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM sales WHERE brand_id = ?", Integer.class, 1L);
+
+        // When & Then
+        api.perform(get("/api/sales/brands/{brandId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(expected)));
+    }
+
+    @Test
+    @DisplayName("test_getSalesByBrand_2: non-positive brandId returns 400")
+    void test_getSalesByBrand_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/brands/{brandId}", -3L))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("test_getSalesByVehicle_1: vehicle with sales returns full list")
+    void test_getSalesByVehicle_1() throws Exception {
+        // Given
+        Integer expected = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM sales WHERE vehicle_id = ?", Integer.class, 1L);
+
+        // When & Then
+        api.perform(get("/api/sales/vehicles/{vehicleId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(expected)));
+    }
+
+    @Test
+    @DisplayName("test_getSalesByVehicle_2: non-positive vehicleId returns 400")
+    void test_getSalesByVehicle_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/vehicles/{vehicleId}", 0L))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("test_getBestSellingVehicles_1: without date range returns up to 5 entries")
+    void test_getBestSellingVehicles_1() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/vehicles/bestSelling"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(5)))
+                .andExpect(jsonPath("$[0].totalSales", greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @DisplayName("test_getBestSellingVehicles_2: inverted date range returns 400")
+    void test_getBestSellingVehicles_2() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/vehicles/bestSelling")
+                        .param("startDate", "2025-02-01")
+                        .param("endDate", "2025-01-01"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("test_getBestSellingVehicles_3: filtering by a narrow range yields a subset")
+    void test_getBestSellingVehicles_3() throws Exception {
+        // When & Then
+        api.perform(get("/api/sales/vehicles/bestSelling")
+                        .param("startDate", "2025-01-01")
+                        .param("endDate", "2025-01-02"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", greaterThanOrEqualTo(1)));
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/controller/BrandControllerSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/controller/BrandControllerSlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.controller;
+
+import com.septeo.ulyses.technical.test.controller.BrandController;
+
+import org.springframework.context.annotation.Import;
+
+@Import(BrandController.class)
+public class BrandControllerSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/controller/SalesControllerSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/controller/SalesControllerSlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.controller;
+
+import com.septeo.ulyses.technical.test.controller.SalesController;
+
+import org.springframework.context.annotation.Import;
+
+@Import(SalesController.class)
+public class SalesControllerSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/CacheConfigSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/CacheConfigSlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.infra;
+
+import com.septeo.ulyses.technical.test.config.CacheConfig;
+
+import org.springframework.context.annotation.Import;
+
+@Import(CacheConfig.class)
+public class CacheConfigSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/JpaSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/JpaSlice.java
@@ -1,0 +1,31 @@
+package com.septeo.ulyses.technical.test.it.slice.infra;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+
+/**
+ * Brings up just the persistence layer (H2 + Hibernate + SQL init) required by
+ * controller/service/repository slices that talk to the real database.
+ *
+ * <p>{@code @EntityScan} is needed because slice tests disable component scanning,
+ * so JPA would otherwise not discover the entities.
+ */
+@EntityScan(basePackages = "com.septeo.ulyses.technical.test.entity")
+@ImportAutoConfiguration({
+        DataSourceAutoConfiguration.class,
+        DataSourceTransactionManagerAutoConfiguration.class,
+        JdbcTemplateAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        SqlInitializationAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        H2ConsoleAutoConfiguration.class
+})
+public class JpaSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/SecuritySlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/infra/SecuritySlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.infra;
+
+import com.septeo.ulyses.technical.test.config.SecurityConfig;
+
+import org.springframework.context.annotation.Import;
+
+@Import(SecurityConfig.class)
+public class SecuritySlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/repository/BrandRepositorySlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/repository/BrandRepositorySlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.repository;
+
+import com.septeo.ulyses.technical.test.repository.BrandRepositoryImpl;
+
+import org.springframework.context.annotation.Import;
+
+@Import(BrandRepositoryImpl.class)
+public class BrandRepositorySlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/repository/SalesRepositorySlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/repository/SalesRepositorySlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.repository;
+
+import com.septeo.ulyses.technical.test.repository.SalesRepositoryImpl;
+
+import org.springframework.context.annotation.Import;
+
+@Import(SalesRepositoryImpl.class)
+public class SalesRepositorySlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/service/BrandServiceSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/service/BrandServiceSlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.service;
+
+import com.septeo.ulyses.technical.test.service.BrandServiceImpl;
+
+import org.springframework.context.annotation.Import;
+
+@Import(BrandServiceImpl.class)
+public class BrandServiceSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/it/slice/service/SalesServiceSlice.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/it/slice/service/SalesServiceSlice.java
@@ -1,0 +1,9 @@
+package com.septeo.ulyses.technical.test.it.slice.service;
+
+import com.septeo.ulyses.technical.test.service.SalesServiceImpl;
+
+import org.springframework.context.annotation.Import;
+
+@Import(SalesServiceImpl.class)
+public class SalesServiceSlice {
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/logging/AccessLogFilterTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/logging/AccessLogFilterTest.java
@@ -1,0 +1,156 @@
+package com.septeo.ulyses.technical.test.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class AccessLogFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    private final AccessLogFilter subject = new AccessLogFilter();
+
+    private final ListAppender appender = new ListAppender();
+    private Logger filterLogger;
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+        this.filterLogger = (Logger) LoggerFactory.getLogger(AccessLogFilter.class);
+        this.previousLevel = this.filterLogger.getLevel();
+        this.filterLogger.setLevel(Level.INFO);
+        this.filterLogger.addAppender(this.appender);
+        this.appender.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.filterLogger.detachAppender(this.appender);
+        this.filterLogger.setLevel(this.previousLevel);
+        this.appender.stop();
+    }
+
+    @Test
+    @DisplayName("doFilterInternal logs method, URL and final response status after the chain runs")
+    void test_doFilterInternal_1() throws ServletException, IOException {
+        // Given
+        when(this.request.getMethod()).thenReturn("GET");
+        when(this.request.getRequestURI()).thenReturn("/api/brands");
+        when(this.request.getQueryString()).thenReturn(null);
+        when(this.response.getStatus()).thenReturn(200);
+
+        // When
+        this.subject.doFilter(this.request, this.response, this.chain);
+
+        // Then
+        verify(this.chain).doFilter(this.request, this.response);
+        assertThat(this.appender.events).hasSize(1);
+        final String message = this.appender.events.get(0).getFormattedMessage();
+        assertThat(message).contains("GET")
+                .contains("/api/brands")
+                .contains("200")
+                .contains("ms");
+    }
+
+    @Test
+    @DisplayName("doFilterInternal appends the query string to the logged URL when present")
+    void test_doFilterInternal_2() throws ServletException, IOException {
+        // Given
+        when(this.request.getMethod()).thenReturn("GET");
+        when(this.request.getRequestURI()).thenReturn("/api/sales");
+        when(this.request.getQueryString()).thenReturn("page=2");
+        when(this.response.getStatus()).thenReturn(200);
+
+        // When
+        this.subject.doFilter(this.request, this.response, this.chain);
+
+        // Then
+        final String message = this.appender.events.get(0).getFormattedMessage();
+        assertThat(message).contains("/api/sales?page=2");
+    }
+
+    @Test
+    @DisplayName("doFilterInternal still logs when the filter chain throws (status captured in finally)")
+    void test_doFilterInternal_3() throws ServletException, IOException {
+        // Given
+        when(this.request.getMethod()).thenReturn("POST");
+        when(this.request.getRequestURI()).thenReturn("/api/brands");
+        when(this.request.getQueryString()).thenReturn(null);
+        when(this.response.getStatus()).thenReturn(500);
+        final ServletException failure = new ServletException("boom");
+        doThrow(failure).when(this.chain).doFilter(this.request, this.response);
+
+        // When & Then
+        assertThatThrownBy(() -> this.subject.doFilter(this.request, this.response, this.chain)).isSameAs(failure);
+        assertThat(this.appender.events).hasSize(1);
+        final String message = this.appender.events.get(0).getFormattedMessage();
+        assertThat(message).contains("POST")
+                .contains("/api/brands")
+                .contains("500");
+    }
+
+    @Test
+    @DisplayName("doFilterInternal reports a non-negative elapsed time")
+    void test_doFilterInternal_4() throws ServletException, IOException {
+        // Given
+        when(this.request.getMethod()).thenReturn("GET");
+        when(this.request.getRequestURI()).thenReturn("/api/vehicles");
+        when(this.request.getQueryString()).thenReturn(null);
+        when(this.response.getStatus()).thenReturn(404);
+        doAnswer(invocation -> {
+            Thread.sleep(2);
+            return null;
+        }).when(this.chain).doFilter(this.request, this.response);
+
+        // When
+        this.subject.doFilter(this.request, this.response, this.chain);
+
+        // Then
+        final String message = this.appender.events.get(0).getFormattedMessage();
+        // pattern ends with "<n>ms" — assert it contains a digit followed by "ms"
+        assertThat(message).matches(".*\\| \\d+ms$");
+    }
+
+    private static final class ListAppender extends AppenderBase<ILoggingEvent> {
+        private final List<ILoggingEvent> events = new ArrayList<>();
+
+        @Override
+        protected void append(final ILoggingEvent event) {
+            this.events.add(event);
+        }
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/repository/SalesRepositoryImplTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/repository/SalesRepositoryImplTest.java
@@ -1,0 +1,196 @@
+package com.septeo.ulyses.technical.test.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import com.septeo.ulyses.technical.test.entity.Sales;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SalesRepositoryImplTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private TypedQuery<Sales> query;
+
+    private SalesRepositoryImpl subject;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.subject = new SalesRepositoryImpl();
+        // EntityManager is @PersistenceContext-injected; set it via reflection for unit tests.
+        final Field field = SalesRepositoryImpl.class.getDeclaredField("entityManager");
+        field.setAccessible(true);
+        field.set(this.subject, this.entityManager);
+    }
+
+    @Test
+    @DisplayName("findAll runs the SELECT-all query and returns its result")
+    void test_findAll_1() {
+        // Given
+        final List<Sales> expected = List.of(new Sales(), new Sales());
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.getResultList()).thenReturn(expected);
+
+        // When
+        final List<Sales> result = this.subject.findAll();
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.query).getResultList();
+        verifyNoMoreInteractions(this.query);
+    }
+
+    @Test
+    @DisplayName("findById returns the entity wrapped in an Optional when found")
+    void test_findById_1() {
+        // Given
+        final Sales sale = new Sales();
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "WHERE s.id = :id",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setParameter("id", 1L)).thenReturn(this.query);
+        when(this.query.getSingleResult()).thenReturn(sale);
+
+        // When
+        final Optional<Sales> result = this.subject.findById(1L);
+
+        // Then
+        assertThat(result).contains(sale);
+    }
+
+    @Test
+    @DisplayName("findById returns empty when the JPA query throws NoResultException")
+    void test_findById_2() {
+        // Given
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "WHERE s.id = :id",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setParameter("id", 99L)).thenReturn(this.query);
+        when(this.query.getSingleResult()).thenThrow(new NoResultException());
+
+        // When
+        final Optional<Sales> result = this.subject.findById(99L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findPage applies pagination using firstResult and maxResults=pageSize+1")
+    void test_findPage_1() {
+        // Given
+        final List<Sales> rows = List.of(new Sales(), new Sales(), new Sales());
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "ORDER BY s.id ASC",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setFirstResult(20)).thenReturn(this.query);
+        when(this.query.setMaxResults(11)).thenReturn(this.query);
+        when(this.query.getResultList()).thenReturn(rows);
+
+        // When
+        final List<Sales> result = this.subject.findPage(3, 10);
+
+        // Then
+        assertThat(result).isSameAs(rows);
+        verify(this.query).setFirstResult(20);
+        verify(this.query).setMaxResults(11);
+    }
+
+    @Test
+    @DisplayName("findPage uses offset 0 for the first page")
+    void test_findPage_2() {
+        // Given
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "ORDER BY s.id ASC",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setFirstResult(0)).thenReturn(this.query);
+        when(this.query.setMaxResults(11)).thenReturn(this.query);
+        when(this.query.getResultList()).thenReturn(List.of());
+
+        // When
+        this.subject.findPage(1, 10);
+
+        // Then
+        verify(this.query).setFirstResult(0);
+        verify(this.query).setMaxResults(11);
+    }
+
+    @Test
+    @DisplayName("findByBrandId binds the brandId parameter and returns the query result")
+    void test_findByBrandId_1() {
+        // Given
+        final List<Sales> expected = List.of(new Sales());
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "WHERE s.brand.id = :brandId",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setParameter("brandId", 7L)).thenReturn(this.query);
+        when(this.query.getResultList()).thenReturn(expected);
+
+        // When
+        final List<Sales> result = this.subject.findByBrandId(7L);
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.query).setParameter("brandId", 7L);
+    }
+
+    @Test
+    @DisplayName("findByVehicleId binds the vehicleId parameter and returns the query result")
+    void test_findByVehicleId_1() {
+        // Given
+        final List<Sales> expected = List.of(new Sales(), new Sales());
+        when(this.entityManager.createQuery(
+                "SELECT s FROM Sales s "
+                        + "JOIN FETCH s.brand "
+                        + "JOIN FETCH s.vehicle "
+                        + "WHERE s.vehicle.id = :vehicleId",
+                Sales.class)).thenReturn(this.query);
+        when(this.query.setParameter("vehicleId", 5L)).thenReturn(this.query);
+        when(this.query.getResultList()).thenReturn(expected);
+
+        // When
+        final List<Sales> result = this.subject.findByVehicleId(5L);
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.query).setParameter("vehicleId", 5L);
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/service/BrandServiceImplTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/service/BrandServiceImplTest.java
@@ -1,0 +1,123 @@
+package com.septeo.ulyses.technical.test.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.septeo.ulyses.technical.test.entity.Brand;
+import com.septeo.ulyses.technical.test.repository.BrandRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BrandServiceImplTest {
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @InjectMocks
+    private BrandServiceImpl subject;
+
+    @Test
+    @DisplayName("getAllBrands delegates to the repository and returns its list")
+    void test_getAllBrands_1() {
+        // Given
+        final List<Brand> expected = List.of(brand(1L), brand(2L));
+        when(this.brandRepository.findAll()).thenReturn(expected);
+
+        // When
+        final List<Brand> result = this.subject.getAllBrands();
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.brandRepository).findAll();
+        verifyNoMoreInteractions(this.brandRepository);
+    }
+
+    @Test
+    @DisplayName("getAllBrands returns an empty list when the repository has no brands")
+    void test_getAllBrands_2() {
+        // Given
+        when(this.brandRepository.findAll()).thenReturn(List.of());
+
+        // When
+        final List<Brand> result = this.subject.getAllBrands();
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getBrandById returns the brand when found")
+    void test_getBrandById_1() {
+        // Given
+        final Brand brand = brand(7L);
+        when(this.brandRepository.findById(7L)).thenReturn(Optional.of(brand));
+
+        // When
+        final Optional<Brand> result = this.subject.getBrandById(7L);
+
+        // Then
+        assertThat(result).contains(brand);
+    }
+
+    @Test
+    @DisplayName("getBrandById returns empty when the brand does not exist")
+    void test_getBrandById_2() {
+        // Given
+        when(this.brandRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When
+        final Optional<Brand> result = this.subject.getBrandById(999L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("saveBrand delegates to the repository and returns the saved brand")
+    void test_saveBrand_1() {
+        // Given
+        final Brand input = brand(null);
+        final Brand saved = brand(42L);
+        when(this.brandRepository.save(input)).thenReturn(saved);
+
+        // When
+        final Brand result = this.subject.saveBrand(input);
+
+        // Then
+        assertThat(result).isSameAs(saved);
+        verify(this.brandRepository).save(input);
+        verifyNoMoreInteractions(this.brandRepository);
+    }
+
+    @Test
+    @DisplayName("deleteBrand delegates to the repository")
+    void test_deleteBrand_1() {
+        // Given
+        final Long id = 5L;
+
+        // When
+        this.subject.deleteBrand(id);
+
+        // Then
+        verify(this.brandRepository).deleteById(id);
+        verifyNoMoreInteractions(this.brandRepository);
+    }
+
+    private static Brand brand(final Long id) {
+        final Brand brand = new Brand();
+        brand.setId(id);
+        brand.setName("name-" + id);
+        return brand;
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/service/SalesServiceImplTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/service/SalesServiceImplTest.java
@@ -1,0 +1,454 @@
+package com.septeo.ulyses.technical.test.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import com.septeo.ulyses.technical.test.dto.BestSellingVehicleResponse;
+import com.septeo.ulyses.technical.test.dto.PageResponse;
+import com.septeo.ulyses.technical.test.dto.PaginationInfo;
+import com.septeo.ulyses.technical.test.entity.Brand;
+import com.septeo.ulyses.technical.test.entity.Sales;
+import com.septeo.ulyses.technical.test.entity.Vehicle;
+import com.septeo.ulyses.technical.test.repository.SalesRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SalesServiceImplTest {
+
+    private static final int PAGE_SIZE = 3;
+
+    @Mock
+    private SalesRepository salesRepository;
+
+    @InjectMocks
+    private SalesServiceImpl subject;
+
+    @Test
+    @DisplayName("getSalesPage returns hasMore=true and drops the lookahead row when repo returns pageSize+1")
+    void test_getSalesPage_1() {
+        // Given
+        final List<Sales> repoRows = List.of(sale(1L), sale(2L), sale(3L), sale(4L));
+        when(this.salesRepository.findPage(1, PAGE_SIZE)).thenReturn(repoRows);
+
+        // When
+        final PageResponse<Sales> response = this.subject.getSalesPage(1, PAGE_SIZE);
+
+        // Then
+        assertThat(response.data()).hasSize(PAGE_SIZE);
+        assertThat(response.data()).containsExactly(repoRows.get(0), repoRows.get(1), repoRows.get(2));
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(true, 1, PAGE_SIZE));
+    }
+
+    @Test
+    @DisplayName("getSalesPage returns hasMore=false when repo returns fewer rows than pageSize")
+    void test_getSalesPage_2() {
+        // Given
+        final List<Sales> repoRows = List.of(sale(1L), sale(2L));
+        when(this.salesRepository.findPage(2, PAGE_SIZE)).thenReturn(repoRows);
+
+        // When
+        final PageResponse<Sales> response = this.subject.getSalesPage(2, PAGE_SIZE);
+
+        // Then
+        assertThat(response.data()).isSameAs(repoRows);
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(false, 2, PAGE_SIZE));
+    }
+
+    @Test
+    @DisplayName("getSalesPage returns hasMore=false when repo returns exactly pageSize")
+    void test_getSalesPage_3() {
+        // Given
+        final List<Sales> repoRows = List.of(sale(1L), sale(2L), sale(3L));
+        when(this.salesRepository.findPage(1, PAGE_SIZE)).thenReturn(repoRows);
+
+        // When
+        final PageResponse<Sales> response = this.subject.getSalesPage(1, PAGE_SIZE);
+
+        // Then
+        assertThat(response.data()).isSameAs(repoRows);
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(false, 1, PAGE_SIZE));
+    }
+
+    @Test
+    @DisplayName("getSalesPage returns empty page when repo returns empty list")
+    void test_getSalesPage_4() {
+        // Given
+        when(this.salesRepository.findPage(5, PAGE_SIZE)).thenReturn(List.of());
+
+        // When
+        final PageResponse<Sales> response = this.subject.getSalesPage(5, PAGE_SIZE);
+
+        // Then
+        assertThat(response.data()).isEmpty();
+        assertThat(response.pagination()).isEqualTo(new PaginationInfo(false, 5, PAGE_SIZE));
+    }
+
+    @Test
+    @DisplayName("getSalesById returns the sale when found")
+    void test_getSalesById_1() {
+        // Given
+        final Sales sale = sale(42L);
+        when(this.salesRepository.findById(42L)).thenReturn(Optional.of(sale));
+
+        // When
+        final Optional<Sales> result = this.subject.getSalesById(42L);
+
+        // Then
+        assertThat(result).contains(sale);
+    }
+
+    @Test
+    @DisplayName("getSalesById returns empty when not found")
+    void test_getSalesById_2() {
+        // Given
+        when(this.salesRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // When
+        final Optional<Sales> result = this.subject.getSalesById(99L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getSalesByBrand delegates to the repository and returns its result")
+    void test_getSalesByBrand_1() {
+        // Given
+        final List<Sales> expected = List.of(sale(1L), sale(2L));
+        when(this.salesRepository.findByBrandId(7L)).thenReturn(expected);
+
+        // When
+        final List<Sales> result = this.subject.getSalesByBrand(7L);
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.salesRepository).findByBrandId(7L);
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getSalesByVehicle delegates to the repository and returns its result")
+    void test_getSalesByVehicle_1() {
+        // Given
+        final List<Sales> expected = List.of(sale(1L));
+        when(this.salesRepository.findByVehicleId(3L)).thenReturn(expected);
+
+        // When
+        final List<Sales> result = this.subject.getSalesByVehicle(3L);
+
+        // Then
+        assertThat(result).isSameAs(expected);
+        verify(this.salesRepository).findByVehicleId(3L);
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles returns top 5 ordered by sales count when no date filter is applied")
+    void test_getBestSellingVehicles_1() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final Vehicle v2 = vehicle(2L, "ModelB", "2021");
+        final Vehicle v3 = vehicle(3L, "ModelC", "2022");
+        final Vehicle v4 = vehicle(4L, "ModelD", "2023");
+        final Vehicle v5 = vehicle(5L, "ModelE", "2024");
+        final Vehicle v6 = vehicle(6L, "ModelF", "2025");
+        // Counts: v1=4, v2=3, v3=2, v4=1, v5=1, v6=1 -> top 5: v1, v2, v3, v4|v5|v6 (ties keep insertion order)
+        final List<Sales> all = List.of(
+                saleOf(v1), saleOf(v1), saleOf(v1), saleOf(v1),
+                saleOf(v2), saleOf(v2), saleOf(v2),
+                saleOf(v3), saleOf(v3),
+                saleOf(v4),
+                saleOf(v5),
+                saleOf(v6));
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        assertThat(response).hasSize(5);
+        assertThat(response.get(0).vehicleId()).isEqualTo(1L);
+        assertThat(response.get(0).totalSales()).isEqualTo(4L);
+        assertThat(response.get(0).brand()).isEqualTo("BrandX");
+        assertThat(response.get(0).model()).isEqualTo("ModelA");
+        assertThat(response.get(0).year()).isEqualTo("2020");
+        assertThat(response.get(1).vehicleId()).isEqualTo(2L);
+        assertThat(response.get(1).totalSales()).isEqualTo(3L);
+        assertThat(response.get(2).vehicleId()).isEqualTo(3L);
+        assertThat(response.get(2).totalSales()).isEqualTo(2L);
+        // Ties at totalSales=1 -> first-seen order in the input is v4, v5, v6.
+        assertThat(response.get(3).vehicleId()).isEqualTo(4L);
+        assertThat(response.get(3).totalSales()).isEqualTo(1L);
+        assertThat(response.get(4).vehicleId()).isEqualTo(5L);
+        assertThat(response.get(4).totalSales()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles filters sales by start and end date inclusively")
+    void test_getBestSellingVehicles_2() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final Vehicle v2 = vehicle(2L, "ModelB", "2021");
+        final LocalDate start = LocalDate.of(2024, 1, 10);
+        final LocalDate end = LocalDate.of(2024, 1, 20);
+        final List<Sales> all = List.of(
+                saleOf(v1, LocalDate.of(2024, 1, 9)),   // out (before start)
+                saleOf(v1, LocalDate.of(2024, 1, 10)),  // in
+                saleOf(v1, LocalDate.of(2024, 1, 15)),  // in
+                saleOf(v2, LocalDate.of(2024, 1, 20)),  // in
+                saleOf(v2, LocalDate.of(2024, 1, 21))); // out (after end)
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(start, end);
+
+        // Then
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0).vehicleId()).isEqualTo(1L);
+        assertThat(response.get(0).totalSales()).isEqualTo(2L);
+        assertThat(response.get(1).vehicleId()).isEqualTo(2L);
+        assertThat(response.get(1).totalSales()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles returns empty when no sales exist")
+    void test_getBestSellingVehicles_3() {
+        // Given
+        when(this.salesRepository.findAll()).thenReturn(List.of());
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles returns empty when all sales are filtered out by date")
+    void test_getBestSellingVehicles_4() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final List<Sales> all = List.of(saleOf(v1, LocalDate.of(2020, 1, 1)));
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
+
+        // Then
+        assertThat(response).isEmpty();
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles breaks ties using first-seen order of each vehicle")
+    void test_getBestSellingVehicles_6() {
+        // Given - all vehicles tie at 2 sales; expected order = first-seen order in the input.
+        final Vehicle v10 = vehicle(10L, "ModelJ", "2020");
+        final Vehicle v20 = vehicle(20L, "ModelT", "2021");
+        final Vehicle v30 = vehicle(30L, "ModelD", "2022");
+        final Vehicle v40 = vehicle(40L, "ModelF", "2023");
+        final List<Sales> all = List.of(
+                saleOf(v30), saleOf(v30),
+                saleOf(v10), saleOf(v10),
+                saleOf(v40), saleOf(v40),
+                saleOf(v20), saleOf(v20));
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        assertThat(response).extracting(BestSellingVehicleResponse::vehicleId)
+                .containsExactly(30L, 10L, 40L, 20L);
+        assertThat(response).extracting(BestSellingVehicleResponse::totalSales)
+                .containsOnly(2L);
+    }
+
+    private static Sales sale(final Long id) {
+        final Sales sale = new Sales();
+        sale.setId(id);
+        return sale;
+    }
+
+    private static Sales saleOf(final Vehicle vehicle) {
+        return saleOf(vehicle, LocalDate.of(2024, 6, 1));
+    }
+
+    private static Sales saleOf(final Vehicle vehicle, final LocalDate saleDate) {
+        final Sales sale = new Sales();
+        sale.setVehicle(vehicle);
+        sale.setSaleDate(saleDate);
+        sale.setPrice(BigDecimal.ONE);
+        return sale;
+    }
+
+    private static Vehicle vehicle(final Long id, final String model, final String year) {
+        final Brand brand = new Brand();
+        brand.setId(1L);
+        brand.setName("BrandX");
+        final Vehicle vehicle = new Vehicle();
+        vehicle.setId(id);
+        vehicle.setBrand(brand);
+        vehicle.setModel(model);
+        vehicle.setYear(year);
+        vehicle.setColor("RED");
+        return vehicle;
+    }
+
+    @Test
+    @DisplayName("getSalesPage does not interact with anything other than the repository")
+    void test_getSalesPage_5() {
+        // Given
+        when(this.salesRepository.findPage(1, PAGE_SIZE)).thenReturn(List.of());
+
+        // When
+        this.subject.getSalesPage(1, PAGE_SIZE);
+
+        // Then
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getSalesById does not interact with anything other than findById")
+    void test_getSalesById_3() {
+        // Given
+        when(this.salesRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When
+        this.subject.getSalesById(1L);
+
+        // Then
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles does not trigger any other repository call")
+    void test_getBestSellingVehicles_5() {
+        // Given
+        when(this.salesRepository.findAll()).thenReturn(List.of());
+
+        // When
+        this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        verify(this.salesRepository).findAll();
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getSalesByBrand returning empty list does not trigger extra interactions")
+    void test_getSalesByBrand_2() {
+        // Given
+        when(this.salesRepository.findByBrandId(1L)).thenReturn(List.of());
+
+        // When
+        final List<Sales> result = this.subject.getSalesByBrand(1L);
+
+        // Then
+        assertThat(result).isEmpty();
+        verifyNoMoreInteractions(this.salesRepository);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles applies only startDate when endDate is null")
+    void test_getBestSellingVehicles_7() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final List<Sales> all = List.of(
+                saleOf(v1, LocalDate.of(2023, 12, 31)), // out (before start)
+                saleOf(v1, LocalDate.of(2024, 1, 1)),   // in (equal to start)
+                saleOf(v1, LocalDate.of(2099, 1, 1)));  // in (no upper bound)
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response =
+                this.subject.getBestSellingVehicles(LocalDate.of(2024, 1, 1), null);
+
+        // Then
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).vehicleId()).isEqualTo(1L);
+        assertThat(response.get(0).totalSales()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles applies only endDate when startDate is null")
+    void test_getBestSellingVehicles_8() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final List<Sales> all = List.of(
+                saleOf(v1, LocalDate.of(1999, 1, 1)),   // in (no lower bound)
+                saleOf(v1, LocalDate.of(2024, 1, 1)),   // in (equal to end)
+                saleOf(v1, LocalDate.of(2024, 1, 2))); // out (after end)
+        when(this.salesRepository.findAll()).thenReturn(all);
+
+        // When
+        final List<BestSellingVehicleResponse> response =
+                this.subject.getBestSellingVehicles(null, LocalDate.of(2024, 1, 1));
+
+        // Then
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).vehicleId()).isEqualTo(1L);
+        assertThat(response.get(0).totalSales()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles returns every distinct vehicle when there are fewer than K")
+    void test_getBestSellingVehicles_9() {
+        // Given
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final Vehicle v2 = vehicle(2L, "ModelB", "2021");
+        when(this.salesRepository.findAll()).thenReturn(List.of(saleOf(v1), saleOf(v2), saleOf(v1)));
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0).vehicleId()).isEqualTo(1L);
+        assertThat(response.get(0).totalSales()).isEqualTo(2L);
+        assertThat(response.get(1).vehicleId()).isEqualTo(2L);
+        assertThat(response.get(1).totalSales()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getBestSellingVehicles returns all vehicles when distinct count equals K")
+    void test_getBestSellingVehicles_10() {
+        // Given - 5 distinct vehicles, all entered into the buffer without rejections.
+        final Vehicle v1 = vehicle(1L, "ModelA", "2020");
+        final Vehicle v2 = vehicle(2L, "ModelB", "2021");
+        final Vehicle v3 = vehicle(3L, "ModelC", "2022");
+        final Vehicle v4 = vehicle(4L, "ModelD", "2023");
+        final Vehicle v5 = vehicle(5L, "ModelE", "2024");
+        when(this.salesRepository.findAll()).thenReturn(List.of(
+                saleOf(v1), saleOf(v1), saleOf(v1), saleOf(v1), saleOf(v1),
+                saleOf(v2), saleOf(v2), saleOf(v2), saleOf(v2),
+                saleOf(v3), saleOf(v3), saleOf(v3),
+                saleOf(v4), saleOf(v4),
+                saleOf(v5)));
+
+        // When
+        final List<BestSellingVehicleResponse> response = this.subject.getBestSellingVehicles(null, null);
+
+        // Then
+        assertThat(response).hasSize(5);
+        assertThat(response).extracting(BestSellingVehicleResponse::vehicleId)
+                .containsExactly(1L, 2L, 3L, 4L, 5L);
+        assertThat(response).extracting(BestSellingVehicleResponse::totalSales)
+                .containsExactly(5L, 4L, 3L, 2L, 1L);
+    }
+
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/service/bestselling/SaleFiltersTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/service/bestselling/SaleFiltersTest.java
@@ -1,0 +1,72 @@
+package com.septeo.ulyses.technical.test.service.bestselling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.function.Predicate;
+
+import com.septeo.ulyses.technical.test.entity.Sales;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SaleFiltersTest {
+
+    @Test
+    @DisplayName("byStartDate returns always-true predicate when startDate is null")
+    void test_byStartDate_1() {
+        // Given
+        final Sales sale = saleOn(LocalDate.of(1900, 1, 1));
+
+        // When
+        final Predicate<Sales> predicate = SaleFilters.byStartDate(null);
+
+        // Then
+        assertThat(predicate.test(sale)).isTrue();
+    }
+
+    @Test
+    @DisplayName("byStartDate accepts sales on or after the start date")
+    void test_byStartDate_2() {
+        // Given
+        final LocalDate startDate = LocalDate.of(2024, 6, 1);
+        final Predicate<Sales> predicate = SaleFilters.byStartDate(startDate);
+
+        // When & Then
+        assertThat(predicate.test(saleOn(startDate))).isTrue();
+        assertThat(predicate.test(saleOn(startDate.plusDays(1)))).isTrue();
+        assertThat(predicate.test(saleOn(startDate.minusDays(1)))).isFalse();
+    }
+
+    @Test
+    @DisplayName("byEndDate returns always-true predicate when endDate is null")
+    void test_byEndDate_1() {
+        // Given
+        final Sales sale = saleOn(LocalDate.of(9999, 12, 31));
+
+        // When
+        final Predicate<Sales> predicate = SaleFilters.byEndDate(null);
+
+        // Then
+        assertThat(predicate.test(sale)).isTrue();
+    }
+
+    @Test
+    @DisplayName("byEndDate accepts sales on or before the end date")
+    void test_byEndDate_2() {
+        // Given
+        final LocalDate endDate = LocalDate.of(2024, 6, 1);
+        final Predicate<Sales> predicate = SaleFilters.byEndDate(endDate);
+
+        // When & Then
+        assertThat(predicate.test(saleOn(endDate))).isTrue();
+        assertThat(predicate.test(saleOn(endDate.minusDays(1)))).isTrue();
+        assertThat(predicate.test(saleOn(endDate.plusDays(1)))).isFalse();
+    }
+
+    private static Sales saleOn(final LocalDate date) {
+        final Sales sale = new Sales();
+        sale.setSaleDate(date);
+        return sale;
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/service/bestselling/TopKSelectorTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/service/bestselling/TopKSelectorTest.java
@@ -1,0 +1,134 @@
+package com.septeo.ulyses.technical.test.service.bestselling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.function.ToLongFunction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TopKSelectorTest {
+
+    private static final ToLongFunction<Long> VALUE_EXTRACTOR = value -> value;
+
+    @Test
+    @DisplayName("of returns top K elements in descending order")
+    void test_of_1() {
+        // Given
+        final List<Long> input = List.of(3L, 1L, 5L, 2L, 4L, 7L, 6L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 3, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(7L, 6L, 5L);
+    }
+
+    @Test
+    @DisplayName("of returns all elements when K is greater than input size")
+    void test_of_2() {
+        // Given
+        final List<Long> input = List.of(2L, 1L, 3L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 10, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(3L, 2L, 1L);
+    }
+
+    @Test
+    @DisplayName("of preserves first-seen order when values tie")
+    void test_of_3() {
+        // Given
+        final Long first = 5L;
+        final Long second = 5L;
+        final Long third = 5L;
+        final List<Long> input = List.of(first, second, third);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 2, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isSameAs(first);
+        assertThat(result.get(1)).isSameAs(second);
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("provide_of_edge_cases")
+    @DisplayName("of returns empty list for edge cases (null, empty or non-positive K)")
+    void test_of_4(final List<Long> input, final int k) {
+        // Given & When
+        final List<Long> result = TopKSelector.of(input, k, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    private static Stream<Arguments> provide_of_edge_cases() {
+        return Stream.of(
+                Arguments.of(Named.of("null input", null), 5),
+                Arguments.of(Named.of("empty input", List.of()), 5),
+                Arguments.of(Named.of("K = 0", List.of(1L, 2L)), 0),
+                Arguments.of(Named.of("K negative", List.of(1L, 2L)), -3));
+    }
+
+    @Test
+    @DisplayName("of handles single-element input")
+    void test_of_5() {
+        // Given
+        final List<Long> input = List.of(42L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 5, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(42L);
+    }
+
+    @Test
+    @DisplayName("of inserts in the middle when value falls between existing values")
+    void test_of_6() {
+        // Given - candidate goes between first and last while buffer is full
+        final List<Long> input = List.of(10L, 1L, 5L, 7L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 3, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(10L, 7L, 5L);
+    }
+
+    @Test
+    @DisplayName("of rejects values that do not beat the current threshold once buffer is full")
+    void test_of_7() {
+        // Given
+        final List<Long> input = List.of(10L, 9L, 8L, 1L, 2L, 3L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 3, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(10L, 9L, 8L);
+    }
+
+    @Test
+    @DisplayName("of works with negative values")
+    void test_of_8() {
+        // Given
+        final List<Long> input = List.of(-5L, -10L, -1L, -7L);
+
+        // When
+        final List<Long> result = TopKSelector.of(input, 2, VALUE_EXTRACTOR);
+
+        // Then
+        assertThat(result).containsExactly(-1L, -5L);
+    }
+}

--- a/src/test/java/com/septeo/ulyses/technical/test/validation/RequestValidationsTest.java
+++ b/src/test/java/com/septeo/ulyses/technical/test/validation/RequestValidationsTest.java
@@ -1,0 +1,109 @@
+package com.septeo.ulyses.technical.test.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class RequestValidationsTest {
+
+    @Test
+    @DisplayName("positive succeeds with a positive value")
+    void test_positive_1() {
+        // Given, When & Then
+        assertThatCode(() -> RequestValidations.positive(1L, "id")).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("provide_positive_invalid_cases")
+    @DisplayName("positive throws 400 for null or non-positive values")
+    void test_positive_2(final Long value) {
+        // Given, When & Then
+        assertThatThrownBy(() -> RequestValidations.positive(value, "id"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    final ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(rse.getReason()).isEqualTo("id must be a positive number");
+                });
+    }
+
+    private static Stream<Arguments> provide_positive_invalid_cases() {
+        return Stream.of(
+                Arguments.of(Named.of("null value", (Long) null)),
+                Arguments.of(Named.of("zero value", 0L)),
+                Arguments.of(Named.of("negative value", -5L)));
+    }
+
+    @Test
+    @DisplayName("minimum succeeds when value equals the minimum")
+    void test_minimum_1() {
+        // Given, When & Then
+        assertThatCode(() -> RequestValidations.minimum(1, 1, "page")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("minimum succeeds when value is greater than the minimum")
+    void test_minimum_2() {
+        // Given, When & Then
+        assertThatCode(() -> RequestValidations.minimum(10, 1, "page")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("minimum throws 400 when value is below the minimum")
+    void test_minimum_3() {
+        // Given, When & Then
+        assertThatThrownBy(() -> RequestValidations.minimum(0, 1, "page"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    final ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(rse.getReason()).isEqualTo("page must be >= 1");
+                });
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("provide_dateRange_valid_cases")
+    @DisplayName("dateRange accepts null bounds and start <= end")
+    void test_dateRange_1(final LocalDate startDate, final LocalDate endDate) {
+        // Given, When & Then
+        assertThatCode(() -> RequestValidations.dateRange(startDate, endDate)).doesNotThrowAnyException();
+    }
+
+    private static Stream<Arguments> provide_dateRange_valid_cases() {
+        return Stream.of(
+                Arguments.of(Named.of("both null", null), null),
+                Arguments.of(Named.of("only start", LocalDate.of(2024, 1, 1)), null),
+                Arguments.of(Named.of("only end", null), LocalDate.of(2024, 1, 1)),
+                Arguments.of(Named.of("start before end", LocalDate.of(2024, 1, 1)), LocalDate.of(2024, 12, 31)),
+                Arguments.of(Named.of("start equals end", LocalDate.of(2024, 6, 1)), LocalDate.of(2024, 6, 1)));
+    }
+
+    @Test
+    @DisplayName("dateRange throws 400 when start is after end")
+    void test_dateRange_2() {
+        // Given
+        final LocalDate startDate = LocalDate.of(2024, 12, 31);
+        final LocalDate endDate = LocalDate.of(2024, 1, 1);
+
+        // When & Then
+        assertThatThrownBy(() -> RequestValidations.dateRange(startDate, endDate))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    final ResponseStatusException rse = (ResponseStatusException) ex;
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(rse.getReason()).isEqualTo("startDate must be before or equal to endDate");
+                });
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,28 @@
+# Test profile properties (loaded by @ActiveProfiles("test"))
+# Override only what the IT slices need; everything else is inherited from application.properties.
+
+# Reuse the in-memory H2 created by DataSourceAutoConfiguration in tests
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=LEGACY
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+
+# JPA + SQL init
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+
+# Short cache TTL so we never depend on production defaults
+app.cache.brands.ttl-seconds=60
+
+# Security credentials needed by SecurityConfig when it is loaded by a slice
+app.security.user.username=user
+app.security.user.password=user
+app.security.admin.username=admin
+app.security.admin.password=admin
+
+# Send access log to a throwaway file; the logback profile filter keeps it from
+# breaking when not loaded.
+app.access-log.file=target/test-access.log
+
+logging.level.com.septeo.ulyses.technical.test=WARN


### PR DESCRIPTION
<head></head><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Summary</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">This PR implements the requested technical test requirements, including authentication/authorization, sales endpoints, best-selling vehicles calculation, access logging, and a custom TTL cache implementation.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">I have also added tests around the classes that were created or modified as part of the exercise, keeping the test scope focused on the requested changes.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">I have included a few technical notes below to make some implementation decisions explicit and easier to review. I will be happy to discuss and defend both the decisions documented here and the ones that were left implicit in the code, if needed.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Technical notes about the implementation</h2><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Fetch strategy in<span class="Apple-converted-space"> </span><code inline="">SalesRepository</code><span class="Apple-converted-space"> </span>— requirements 2 and 3</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Requirement 3 asks to consider performance and to imagine millions of records, while also suggesting keeping<span class="Apple-converted-space"> </span><code inline="">findAll</code>as a reference. A literal interpretation conflicted with the performance requirement: with<span class="Apple-converted-space"> </span><code inline="">@ManyToOne</code><span class="Apple-converted-space"> </span>using the default<span class="Apple-converted-space"> </span><code inline="">EAGER</code><span class="Apple-converted-space"> </span>fetch type, Hibernate executes<span class="Apple-converted-space"> </span><code inline="">findAll</code><span class="Apple-converted-space"> </span>and then triggers an additional<span class="Apple-converted-space"> </span><code inline="">SELECT</code><span class="Apple-converted-space"> </span>for each<span class="Apple-converted-space"> </span><code inline="">vehicle</code><span class="Apple-converted-space"> </span>and each<span class="Apple-converted-space"> </span><code inline="">brand</code>when iterating the result in<span class="Apple-converted-space"> </span><code inline="">SalesServiceImpl.getBestSellingVehicles</code>, producing an N+1 query pattern.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Decision taken:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p>Added<span class="Apple-converted-space"> </span><code inline="">JOIN FETCH s.brand JOIN FETCH s.vehicle</code><span class="Apple-converted-space"> </span>to the five queries in<span class="Apple-converted-space"> </span><code inline="">SalesRepositoryImpl</code>:</p><ul><li><p><code inline="">findAll</code></p></li><li><p><code inline="">findById</code></p></li><li><p><code inline="">findPage</code></p></li><li><p><code inline="">findByBrandId</code></p></li><li><p><code inline="">findByVehicleId</code></p></li></ul></li><li><p>Changed the two<span class="Apple-converted-space"> </span><code inline="">@ManyToOne</code><span class="Apple-converted-space"> </span>associations in<span class="Apple-converted-space"> </span><code inline="">Sales</code><span class="Apple-converted-space"> </span>to<span class="Apple-converted-space"> </span><code inline="">FetchType.LAZY</code>.</p></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The rest of the project remains intentionally unchanged:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p><code inline="">Sales.brand</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">Sales.vehicle</code><span class="Apple-converted-space"> </span>are declared as<span class="Apple-converted-space"> </span><code inline="">LAZY</code><span class="Apple-converted-space"> </span>to avoid the classic default<span class="Apple-converted-space"> </span><code inline="">EAGER</code><span class="Apple-converted-space"> </span>anti-pattern. The repository controls graph loading through<span class="Apple-converted-space"> </span><code inline="">JOIN FETCH</code>, rather than letting the entity define it globally.</p></li><li><p>Since all queries in<span class="Apple-converted-space"> </span><code inline="">SalesRepositoryImpl</code><span class="Apple-converted-space"> </span>hydrate both associations, the repository does not return partially initialized<span class="Apple-converted-space"> </span><code inline="">Sales</code><span class="Apple-converted-space"> </span>objects for these use cases.</p></li><li><p><code inline="">Vehicle.brand</code><span class="Apple-converted-space"> </span>remains<span class="Apple-converted-space"> </span><code inline="">EAGER</code>, as changing it would be outside the scope of this exercise and would require touching<span class="Apple-converted-space"> </span><code inline="">VehicleRepository</code>.</p></li><li><p><code inline="">BrandRepository</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">VehicleRepository</code><span class="Apple-converted-space"> </span>are unchanged.</p></li><li><p>No Hibernate-specific annotations such as<span class="Apple-converted-space"> </span><code inline="">@BatchSize</code><span class="Apple-converted-space"> </span>and no Jackson-specific annotations for lazy proxies were added, because the required graph is already fully loaded through<span class="Apple-converted-space"> </span><code inline="">JOIN FETCH</code>.</p></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Result: sales endpoints can be served with a single<span class="Apple-converted-space"> </span><code inline="">SELECT</code><span class="Apple-converted-space"> </span>using two<span class="Apple-converted-space"> </span><code inline="">INNER JOIN</code>s, avoiding N+1 queries and avoiding partial graphs being serialized.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code inline="">getBestSellingVehicles</code><span class="Apple-converted-space"> </span>runs inside a<span class="Apple-converted-space"> </span><code inline="">@Transactional(readOnly = true)</code><span class="Apple-converted-space"> </span>boundary and returns a<span class="Apple-converted-space"> </span><code inline="">BestSellingVehicleResponse</code><span class="Apple-converted-space"> </span>DTO, so the<span class="Apple-converted-space"> </span><code inline="">Sales</code><span class="Apple-converted-space"> </span>entity itself is not serialized by that endpoint. The decision mainly affects database access cost.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Access logging — requirement 4</h3><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Chosen design</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The access logging implementation uses a custom<span class="Apple-converted-space"> </span><code inline="">AccessLogFilter</code><span class="Apple-converted-space"> </span>extending<span class="Apple-converted-space"> </span><code inline="">OncePerRequestFilter</code>, annotated with<span class="Apple-converted-space"> </span><code inline="">@Component</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">@Order(Ordered.HIGHEST_PRECEDENCE)</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The filter builds the access log line using the requested fields:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p>ISO-8601 timestamp</p></li><li><p>HTTP method</p></li><li><p>URL including query string</p></li><li><p>Final response status</p></li><li><p>Processing time in milliseconds</p></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The line is emitted through SLF4J.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Physical writing to<span class="Apple-converted-space"> </span><code inline="">access.log</code><span class="Apple-converted-space"> </span>is delegated to a dedicated Logback<span class="Apple-converted-space"> </span><code inline="">FileAppender</code>, configured in<span class="Apple-converted-space"> </span><code inline="">logback-spring.xml</code><span class="Apple-converted-space"> </span>with<span class="Apple-converted-space"> </span><code inline="">additivity=false</code>, so access log lines do not pollute the root or console logs.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The file destination is configurable through:</p><pre style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code class="language-properties">app.access-log.file
</code></pre><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Why<span class="Apple-converted-space"> </span><code inline="">@Order(Ordered.HIGHEST_PRECEDENCE)</code><span class="Apple-converted-space"> </span>instead of<span class="Apple-converted-space"> </span><code inline="">FilterRegistrationBean</code></h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Without explicit ordering, Spring Boot may register the filter after Spring Security. In that case,<span class="Apple-converted-space"> </span><code inline="">401</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">403</code><span class="Apple-converted-space"> </span>responses may either be logged with an incorrect status or not logged as intended.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Pinning the filter to<span class="Apple-converted-space"> </span><code inline="">HIGHEST_PRECEDENCE</code><span class="Apple-converted-space"> </span>ensures it wraps the security chain and that the status read from<span class="Apple-converted-space"> </span><code inline="">response.getStatus()</code><span class="Apple-converted-space"> </span>in the<span class="Apple-converted-space"> </span><code inline="">finally</code><span class="Apple-converted-space"> </span>block is the final response status.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">A<span class="Apple-converted-space"> </span><code inline="">FilterRegistrationBean</code><span class="Apple-converted-space"> </span>was not used because this implementation does not need custom URL patterns, dispatcher types, or init parameters. Keeping the ordering decision next to the filter through<span class="Apple-converted-space"> </span><code inline="">@Order</code><span class="Apple-converted-space"> </span>avoids an additional configuration class and keeps the intent visible where the behavior is implemented.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Why file writing is delegated to Logback instead of doing manual I/O with an<span class="Apple-converted-space"> </span><code inline="">ExecutorService</code></h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The custom Spring-based part requested by the exercise is the filter, and that part is implemented manually.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The physical logging destination is delegated to Logback for consistency and maintainability:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p>Requirement 5 explicitly asks to handle concurrency properly for the cache, which is a clear signal that a manual implementation is expected there.</p></li><li><p>Requirement 4 does not mention concurrency, rotation, async processing, or low-level I/O handling, so reimplementing a logging subsystem would add complexity without improving the requested behavior.</p></li><li><p>Logback is not an additional external dependency; it is already provided by<span class="Apple-converted-space"> </span><code inline="">spring-boot-starter-logging</code>, transitively included by<span class="Apple-converted-space"> </span><code inline="">spring-boot-starter-web</code>.</p></li><li><p>A Logback<span class="Apple-converted-space"> </span><code inline="">FileAppender</code><span class="Apple-converted-space"> </span>already handles thread-safety, safe append behavior, and clean shutdown. Reimplementing this with<span class="Apple-converted-space"> </span><code inline="">synchronized + BufferedWriter</code><span class="Apple-converted-space"> </span>or an<span class="Apple-converted-space"> </span><code inline="">ExecutorService</code><span class="Apple-converted-space"> </span>would increase the bug surface without adding value for the requested requirements.</p></li></ul><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">How to verify it</h4><pre style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code class="language-bash"># Generate traffic
curl -i http://localhost:8080/api/brands

curl -i -X POST http://localhost:8080/api/brands \
  -H "Content-Type: application/json" \
  -d '{"name":"X"}'

curl -i -u admin:admin -X POST http://localhost:8080/api/brands \
  -H "Content-Type: application/json" \
  -d '{"name":"X"}'

# Check the access log file
tail -f logs/access.log
</code></pre><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Testing strategy</h2><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Scope</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Tests were added only for classes that were created or modified to solve the requested requirements. Pre-existing code that was not modified is intentionally not covered by these tests, in order to keep the scope focused on the technical test.</p>
Class / package | Test type | Reason
-- | -- | --
cache/* | Unit | Implemented for requirement 5, including a concurrency test with CyclicBarrier.
config/CacheConfig | Covered by BrandCacheIT | Requirement 5.
config/SecurityConfig | Covered by SalesControllerITand BrandCacheIT | Requirement 1. Integration tests run with filters enabled, so the real security chain is validated end-to-end, including 401 and 403 cases.
controller/SalesController | Unit + integration | New endpoints for requirements 2 and 3.
controller/BrandController | Covered by BrandCacheIT | Only involved in the cache flow for requirement 5.
dto/*, service/bestselling/* | Unit | Created for requirement 3.
logging/AccessLogFilter | Unit | Created for requirement 4.
repository/SalesRepositoryImpl | Unit, mocking EntityManager | Modified for requirement 2, including pagination with pageSize + 1.
repository/BrandRepositoryImpl | Covered by BrandCacheIT | No functional changes; validated indirectly.
service/SalesServiceImpl | Unit | New logic for requirement 3.
service/BrandServiceImpl | Unit + integration | Cache annotations for requirement 5.
validation/RequestValidations | Unit | New utility.

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Spring/JPA generated or framework-driven classes, such as entities, repository interfaces, and<span class="Apple-converted-space"> </span><code inline="">Application.java</code>, do not contain custom logic and are therefore not tested directly.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Integration tests designed for CI/CD</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The integration tests are designed to run efficiently in CI/CD pipelines.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Manual slicing without a servlet container</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code inline="">@WebMvcTest</code><span class="Apple-converted-space"> </span>starts only the<span class="Apple-converted-space"> </span><code inline="">WebApplicationContext</code><span class="Apple-converted-space"> </span>with<span class="Apple-converted-space"> </span><code inline="">MockMvc</code>. Tomcat is not started and no port is opened.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Each integration test imports only what it needs through dedicated slice classes under<span class="Apple-converted-space"> </span><code inline="">it/slice/</code>, such as:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p><code inline="">SalesControllerSlice</code></p></li><li><p><code inline="">BrandServiceSlice</code></p></li><li><p><code inline="">JpaSlice</code></p></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">This avoids using<span class="Apple-converted-space"> </span><code inline="">@SpringBootTest</code><span class="Apple-converted-space"> </span>with the full classpath when it is not necessary.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">One context build per test class</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The Spring TestContext Framework caches each context by its combination of slices, properties, and active profile.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Tests within the same integration test class share that configuration, so the context is built once per class and reused across test methods.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">No test uses<span class="Apple-converted-space"> </span><code inline="">@DirtiesContext</code>. Context isolation is achieved through transactional rollback, not by destroying and rebuilding the Spring context.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Data isolation through transactional rollback</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code inline="">SalesControllerIT</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">BrandCacheIT</code><span class="Apple-converted-space"> </span>are annotated with<span class="Apple-converted-space"> </span><code inline="">@Transactional</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Any<span class="Apple-converted-space"> </span><code inline="">INSERT</code>,<span class="Apple-converted-space"> </span><code inline="">UPDATE</code>, or<span class="Apple-converted-space"> </span><code inline="">DELETE</code><span class="Apple-converted-space"> </span>executed by the flow under test is rolled back at the end of each test method. The next test starts from the original state loaded by<span class="Apple-converted-space"> </span><code inline="">data.sql</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Tests that write to the database explicitly mark the write operation with a<span class="Apple-converted-space"> </span><code inline="">// Restore: ...</code><span class="Apple-converted-space"> </span>comment.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">In-memory H2 and isolated test profile</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><code inline="">@ActiveProfiles("test")</code><span class="Apple-converted-space"> </span>loads<span class="Apple-converted-space"> </span><code inline="">application-test.properties</code>, which points to an in-memory H2 database using<span class="Apple-converted-space"> </span><code inline="">mem:testdb</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code inline="">create-drop</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">There is no external database server and no side effect outside the test context.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Mocking only what is outside the tested flow</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">The integration tests do not mock components that are part of the tested flow.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">Controllers, services, repositories, and security filters are real. Security filters are active, so authentication and authorization scenarios are tested inline:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);"><li><p><code inline="">401</code></p></li><li><p><code inline="">403</code></p></li><li><p>valid credentials with<span class="Apple-converted-space"> </span><code inline="">httpBasic("admin", "admin")</code></p></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">This avoids requiring a separate security-only integration test while still validating the real secured behavior end-to-end.</p>